### PR TITLE
Made the variable data in subscription optional

### DIFF
--- a/AppSyncRealTimeClient.podspec
+++ b/AppSyncRealTimeClient.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         = 'AppSyncRealTimeClient'
-    s.version      = '1.0.0'
+    s.version      = '1.0.1'
     s.summary      = 'Amazon Web Services AppSync RealTime Client for iOS.'
   
     s.description  = 'AppSync RealTime Client provides subscription connections to AppSync websocket endpoints'

--- a/AppSyncRealTimeClient.xcodeproj/project.pbxproj
+++ b/AppSyncRealTimeClient.xcodeproj/project.pbxproj
@@ -206,9 +206,9 @@
 		217F39BB2406E98300F1A0B3 /* AppSyncConnection */ = {
 			isa = PBXGroup;
 			children = (
-				217F39BC2406E98300F1A0B3 /* AppSyncSubscriptionConnection+DataHandler.swift */,
 				217F39BD2406E98300F1A0B3 /* AppSyncSubscriptionConnection.swift */,
 				217F39BE2406E98300F1A0B3 /* AppSyncSubscriptionConnection+Connection.swift */,
+				217F39BC2406E98300F1A0B3 /* AppSyncSubscriptionConnection+DataHandler.swift */,
 				217F39BF2406E98300F1A0B3 /* AppSyncSubscriptionConnection+ErrorHandler.swift */,
 			);
 			path = AppSyncConnection;

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+Connection.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+Connection.swift
@@ -37,7 +37,7 @@ extension AppSyncSubscriptionConnection {
         connectionProvider?.write(message)
     }
 
-    private func convertToPayload(for query: String, variables: [String: Any]?) -> AppSyncMessage.Payload {
+    private func convertToPayload(for query: String, variables: [String: Any?]?) -> AppSyncMessage.Payload {
         var dataDict: [String: Any] = ["query": query]
         if let subVariables = variables {
             dataDict["variables"] = subVariables

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
@@ -35,7 +35,7 @@ public class AppSyncSubscriptionConnection: SubscriptionConnection, RetryableCon
     }
 
     public func subscribe(requestString: String,
-                   variables: [String: Any]?,
+                   variables: [String: Any?]?,
                    eventHandler: @escaping (SubscriptionItemEvent, SubscriptionItem) -> Void) -> SubscriptionItem {
         subscriptionItem = SubscriptionItem(requestString: requestString,
                                             variables: variables,

--- a/AppSyncRealTimeClient/Connection/SubscriptionConnection.swift
+++ b/AppSyncRealTimeClient/Connection/SubscriptionConnection.swift
@@ -15,7 +15,7 @@ public protocol SubscriptionConnection {
     /// - Parameter requestString: query for the subscription
     /// - Parameter eventHandler: event handler
     func subscribe(requestString: String,
-                   variables: [String: Any]?,
+                   variables: [String: Any?]?,
                    eventHandler: @escaping SubscriptionEventHandler) -> SubscriptionItem
 
     /// Unsubscribe from the subscription

--- a/AppSyncRealTimeClient/Connection/SubscriptionItem.swift
+++ b/AppSyncRealTimeClient/Connection/SubscriptionItem.swift
@@ -14,7 +14,7 @@ public struct SubscriptionItem {
     let identifier: String
 
     /// Subscription variables for the query
-    let variables: [String: Any]?
+    let variables: [String: Any?]?
 
     /// Request query for subscription
     let requestString: String
@@ -23,7 +23,7 @@ public struct SubscriptionItem {
     let subscriptionEventHandler: SubscriptionEventHandler
 
     init(requestString: String,
-         variables: [String: Any]?,
+         variables: [String: Any?]?,
          eventHandler: @escaping SubscriptionEventHandler) {
 
         self.identifier = UUID().uuidString

--- a/AppSyncRealTimeClientTests/Connection/AppSyncSubscriptionConnectionTests.swift
+++ b/AppSyncRealTimeClientTests/Connection/AppSyncSubscriptionConnectionTests.swift
@@ -205,4 +205,33 @@ class AppSyncSubscriptionConnectionTests: XCTestCase {
         wait(for: [dataEventExpectation], timeout: 2)
     }
 
+    func testNilDataInVariables() {
+        let variablesWithNil = ["key": nil] as [String : Any?]
+        let connectionProvider = MockConnectionProvider()
+        let connection = AppSyncSubscriptionConnection(provider: connectionProvider)
+
+        let connectingMessageExpectation = expectation(description: "Connecting event should be fired")
+        let connectedMessageExpectation = expectation(description: "Connected event should be fired")
+
+        let item = connection.subscribe(requestString: mockRequestString,
+                                        variables: variablesWithNil) { (event, item) in
+            switch event {
+            case .connection(let status):
+
+                if status == .connected {
+                    connectedMessageExpectation.fulfill()
+                }
+                if status == .connecting {
+                    connectingMessageExpectation.fulfill()
+                }
+            case .data:
+                XCTFail("Data event should not be published")
+            case .failed:
+                XCTFail("Error should not be thrown")
+            }
+        }
+        XCTAssertNotNil(item, "Subscription item should not be nil")
+        wait(for: [connectingMessageExpectation, connectedMessageExpectation], timeout: 5, enforceOrder: true)
+    }
+
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# AppSync RealTime Client for iOS
+
+
+## 1.0.1
+
+### Bug Fixes
+- Changed the variable in subscription to get nil as the data in the dictionary. See [PR #3](https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/3)
+
+## 1.0.0
+Initial commit


### PR DESCRIPTION
The subscription api supports passing in a data in variable with nill value. But the new subscription realtime connection code was not setup to
receive that value. This change fixes that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
