### PR TITLE
Fix subscription threading issue

### DIFF
--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -28,6 +28,8 @@ public class RealtimeConnectionProvider: ConnectionProvider {
 
     let serialCallbackQueue = DispatchQueue(label: "com.amazonaws.AppSyncRealTimeConnectionProvider.callbackQueue")
 
+    let serialWriteQueue = DispatchQueue(label: "com.amazonaws.AppSyncRealTimeConnectionProvider.writeQueue")
+
     public init(for url: URL, websocket: AppSyncWebsocketProvider) {
         self.url = url
         self.websocket = websocket
@@ -57,29 +59,48 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     }
 
     public func write(_ message: AppSyncMessage) {
-        let signedMessage = interceptMessage(message, for: url)
-        let jsonEncoder = JSONEncoder()
-        do {
-            let jsonData = try jsonEncoder.encode(signedMessage)
-            guard let jsonString = String(data: jsonData, encoding: .utf8) else {
-                updateCallback(event: .error(ConnectionProviderError.jsonParse(message.id, nil)))
+
+        serialWriteQueue.async { [weak self] in
+            guard let self = self else {
                 return
             }
-            websocket.write(message: jsonString)
-        } catch {
-            AppSyncLogger.error(error)
-            switch message.messageType {
-            case .connectionInit:
-                serialConnectionQueue.async {[weak self] in
-                    guard let self = self else {
-                        return
-                    }
-                    self.status = .notConnected
-                    self.updateCallback(event: .error(ConnectionProviderError.connection))
+
+            let signedMessage = self.interceptMessage(message, for: self.url)
+            let jsonEncoder = JSONEncoder()
+            do {
+                let jsonData = try jsonEncoder.encode(signedMessage)
+                guard let jsonString = String(data: jsonData, encoding: .utf8) else {
+                    let jsonError = ConnectionProviderError.jsonParse(message.id, nil)
+                    self.updateCallback(event: .error(jsonError))
+                    return
                 }
-            default:
-                updateCallback(event: .error(ConnectionProviderError.jsonParse(message.id, error)))
+                self.websocket.write(message: jsonString)
+            } catch {
+                AppSyncLogger.error(error)
+                switch message.messageType {
+                case .connectionInit:
+                    self.serialConnectionQueue.async {[weak self] in
+                        guard let self = self else {
+                            return
+                        }
+                        self.status = .notConnected
+                        self.updateCallback(event: .error(ConnectionProviderError.connection))
+                    }
+                default:
+                    self.updateCallback(event: .error(ConnectionProviderError.jsonParse(message.id, error)))
+                }
             }
+        }
+
+    }
+
+    func receivedConnectionInit() {
+        self.serialConnectionQueue.async {[weak self] in
+            guard let self = self else {
+                return
+            }
+            self.status = .notConnected
+            self.updateCallback(event: .error(ConnectionProviderError.connection))
         }
     }
 

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -88,16 +88,6 @@ public class RealtimeConnectionProvider: ConnectionProvider {
 
     }
 
-    func receivedConnectionInit() {
-        self.serialConnectionQueue.async {[weak self] in
-            guard let self = self else {
-                return
-            }
-            self.status = .notConnected
-            self.updateCallback(event: .error(ConnectionProviderError.connection))
-        }
-    }
-
     public func disconnect() {
         websocket.disconnect()
     }
@@ -124,6 +114,16 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     func updateCallback(event: ConnectionProviderEvent) {
         serialCallbackQueue.async { [weak self] in
             self?.listeners.values.forEach { $0(event) }
+        }
+    }
+
+    func receivedConnectionInit() {
+        self.serialConnectionQueue.async {[weak self] in
+            guard let self = self else {
+                return
+            }
+            self.status = .notConnected
+            self.updateCallback(event: .error(ConnectionProviderError.connection))
         }
     }
 }

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -79,13 +79,7 @@ public class RealtimeConnectionProvider: ConnectionProvider {
                 AppSyncLogger.error(error)
                 switch message.messageType {
                 case .connectionInit:
-                    self.serialConnectionQueue.async {[weak self] in
-                        guard let self = self else {
-                            return
-                        }
-                        self.status = .notConnected
-                        self.updateCallback(event: .error(ConnectionProviderError.connection))
-                    }
+                    self.receivedConnectionInit()
                 default:
                     self.updateCallback(event: .error(ConnectionProviderError.jsonParse(message.id, error)))
                 }

--- a/AppSyncRealTimeClient/Interceptor/RealtimeGatewayURLInterceptor.swift
+++ b/AppSyncRealTimeClient/Interceptor/RealtimeGatewayURLInterceptor.swift
@@ -8,9 +8,13 @@
 import Foundation
 
 /// Connection interceptor for real time connection provider
-class RealtimeGatewayURLInterceptor: ConnectionInterceptor {
+public class RealtimeGatewayURLInterceptor: ConnectionInterceptor {
 
-    func interceptConnection(_ request: AppSyncConnectionRequest,
+    public init() {
+
+    }
+    
+    public func interceptConnection(_ request: AppSyncConnectionRequest,
                              for endpoint: URL) -> AppSyncConnectionRequest {
         guard let host = endpoint.host else {
             return request

--- a/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
+++ b/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
@@ -21,6 +21,7 @@ public class StarscreamAdapter: AppSyncWebsocketProvider {
         socket = WebSocket(url: url, protocols: protocols)
         self.delegate = delegate
         socket?.delegate = self
+        socket?.callbackQueue = DispatchQueue(label: "com.amazonaws.StarscreamAdapter.callBack")
         socket?.connect()
     }
 


### PR DESCRIPTION
*Issue [#328](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/328)

*Description of changes:*
This PR moves the calls to websocket into write into a separate queue so that the interceptors wont block any other queue unintentionaly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
