### PR TITLE
Adding cartfile with starscream + minor version bump

### DIFF
--- a/AppSyncRealTimeClient.podspec
+++ b/AppSyncRealTimeClient.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         = 'AppSyncRealTimeClient'
-    s.version      = '1.1.0'
+    s.version      = '1.2.0'
     s.summary      = 'Amazon Web Services AppSync RealTime Client for iOS.'
   
     s.description  = 'AppSync RealTime Client provides subscription connections to AppSync websocket endpoints'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # AppSync RealTime Client for iOS
 
+## 1.2.0
+
+### Improvements
+- Adding Cartfile with dependency on StarScream See [PR #9](https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/9)
+
 ## 1.1.0
 
 ### Improvements

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "daltoniam/starscream" ~> 3.0.2


### PR DESCRIPTION
Missing Cartfile

From my understanding, the consumer (AppSyncClient) will take a dependency on a specific tagged version of this repo. We will need this code change which adds the Cartfile and tag the commit as 1.2.0 for 
1. Cocoapod release
2. and other carthage packages consuming this one with `github "aws-amplify/aws-appsync-realtime-client" ~> 1.2.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
