### PR TITLE
adding cartfile for dependency on starscream

### DIFF
--- a/cartfile
+++ b/cartfile
@@ -1,0 +1,1 @@
+github "daltoniam/starscream" ~> 3.0.2


### PR DESCRIPTION
When installling 1.1.1, the pod issue goes away, but now there's 
```
/Users/x/temp/appsyncRealTimeCarthageTest/Carthage/Checkouts/aws-appsync-realtime-client-ios/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter+Delegate.swift:9:8: error: no such module 'Starscream'
import Starscream
```

I suspect this repo needs it's dependency on starscream via the cartfile


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
