### PR TITLE
Add files required for Carthage users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ Thumbs.db
 **/xcuserdata
 **/*.xcuserdata
 
-*.xcworkspace/
 AppSyncRealTimeClient.xcodeproj/xcuserdata
 AppSyncRealTimeClient.xcworkspace/xcuserdata
 xcuserdata

--- a/AppSyncRealTimeClient.podspec
+++ b/AppSyncRealTimeClient.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.requires_arc = true
     
     s.source_files = 'AppSyncRealTimeClient/**/*.swift'
-    s.dependency 'Starscream', '~> 3.0.2'
+    s.dependency 'Starscream', '3.0.6'
   end

--- a/AppSyncRealTimeClient.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/AppSyncRealTimeClient.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:AppSyncRealTimeClient.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/AppSyncRealTimeClient.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/AppSyncRealTimeClient.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/AppSyncRealTimeClient.xcworkspace/contents.xcworkspacedata
+++ b/AppSyncRealTimeClient.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:AppSyncRealTimeClient.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/AppSyncRealTimeClient.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/AppSyncRealTimeClient.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "daltoniam/starscream" "3.0.6"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "daltoniam/starscream" "3.0.6"

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ target 'AppSyncRealTimeClient' do
   use_frameworks!
 
   # Pods for AppSyncRealTimeClient
-  pod "Starscream", "~> 3.0.2"
+  pod "Starscream", "3.0.6"
   
   target 'AppSyncRealTimeClientTests' do
     # Pods for testing

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Starscream (3.0.6)
 
 DEPENDENCIES:
-  - Starscream (~> 3.0.2)
+  - Starscream (= 3.0.6)
 
 SPEC REPOS:
   https://cdn.cocoapods.org/:
@@ -11,6 +11,6 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
 
-PODFILE CHECKSUM: 17359d5386586332ef5b360983dd28d0481ee58e
+PODFILE CHECKSUM: 648588a9981103f5742beb41a5187d3720505622
 
 COCOAPODS: 1.9.0

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -2,7 +2,7 @@ PODS:
   - Starscream (3.0.6)
 
 DEPENDENCIES:
-  - Starscream (~> 3.0.2)
+  - Starscream (= 3.0.6)
 
 SPEC REPOS:
   https://cdn.cocoapods.org/:
@@ -11,6 +11,6 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
 
-PODFILE CHECKSUM: 17359d5386586332ef5b360983dd28d0481ee58e
+PODFILE CHECKSUM: 648588a9981103f5742beb41a5187d3720505622
 
 COCOAPODS: 1.9.0

--- a/cartfile
+++ b/cartfile
@@ -1,1 +1,0 @@
-github "daltoniam/starscream" "3.0.6"

--- a/cartfile
+++ b/cartfile
@@ -1,1 +1,1 @@
-github "daltoniam/starscream" ~> 3.0.2
+github "daltoniam/starscream" "3.0.6"


### PR DESCRIPTION
Some changes made to enable carthage users
- checking in the workspace file
- decided to take patch version dependency on Starscream (don't think this is needed since pod lock is already on 3.0.6), may revert this change after some testing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
