### PR TITLE
Adding Cartfile with Starscream dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "daltoniam/starscream" "3.0.6"


### PR DESCRIPTION
The Cartfile is needed due to this repo being managed by Cocoapods. Carthage users that install via a Cartfile which points to this repo requires a Cartfile to know which dependencies to additionally pull in, otherwise the resolved dependency only contains AppSyncRealTimeClient.

With the Cartfile that specifies the Starscream in this repository, then Carthage users with a Cartfile that pulls this repository in will additionally pull in Starscream, as seen in the Cartfile.resolved file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
