### PR TITLE
fix: Make SubscriptionItem.init public

### DIFF
--- a/AppSyncRealTimeClient/Connection/SubscriptionItem.swift
+++ b/AppSyncRealTimeClient/Connection/SubscriptionItem.swift
@@ -22,9 +22,9 @@ public struct SubscriptionItem {
     // Subscription related events will be send to this handler.
     let subscriptionEventHandler: SubscriptionEventHandler
 
-    init(requestString: String,
-         variables: [String: Any?]?,
-         eventHandler: @escaping SubscriptionEventHandler) {
+    public init(requestString: String,
+                variables: [String: Any?]?,
+                eventHandler: @escaping SubscriptionEventHandler) {
 
         self.identifier = UUID().uuidString
         self.variables = variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # AppSync RealTime Client for iOS
 
+## 1.2.1
+
+### Misc
+
+- Make SubscriptionItem.init public. See [PR #19](https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/19)
+
 ## 1.2.0
 
 ### Misc


### PR DESCRIPTION
Make SubscriptionItem.init public to allow for `SubscriptionConnection` mocks in other packages to new `SubscriptionItem`s.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
