### PR TITLE
Update Framework Application Extension API Build Settings

### DIFF
--- a/AppSyncRealTimeClient.xcodeproj/project.pbxproj
+++ b/AppSyncRealTimeClient.xcodeproj/project.pbxproj
@@ -1340,6 +1340,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B07A87133C24AA78AF59093C /* Pods-AppSyncRealTimeClient.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = W3DRXD72QU;
@@ -1366,6 +1367,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C73EA796F50FB0196FDF4865 /* Pods-AppSyncRealTimeClient.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = W3DRXD72QU;


### PR DESCRIPTION
* Update APPLICATION_EXTENSION_API_ONLY to YES to restrict API usage to those appropriate for an extension

*Issue #, if available:*

*Description of changes:*
Set APPLICATION_EXTENSION_API_ONLY build setting to YES for the framework target.  Including the framework in an extension, produces a `warning: linking against dylib not safe for use in application extensions` warning otherwise, but it doesn't look like the framework uses any API that would need the setting set to NO. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
