### PR TITLE
fix: Fix race condition in disconnect; protect status & write access

### DIFF
--- a/AppSyncRealTimeClient.xcodeproj/xcshareddata/xcschemes/AppSyncRealTimeClientIntegrationTests.xcscheme
+++ b/AppSyncRealTimeClient.xcodeproj/xcshareddata/xcschemes/AppSyncRealTimeClientIntegrationTests.xcscheme
@@ -17,6 +17,16 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "217F39972405D9D500F1A0B3"
+               BuildableName = "AppSyncRealTimeClientTests.xctest"
+               BlueprintName = "AppSyncRealTimeClientTests"
+               ReferencedContainer = "container:AppSyncRealTimeClient.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "21D38B3D2409AFBD00EC2A8D"
                BuildableName = "AppSyncRealTimeClientIntegrationTests.xctest"
                BlueprintName = "AppSyncRealTimeClientIntegrationTests"

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+ErrorHandler.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+ErrorHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
@@ -35,7 +35,7 @@ extension RealtimeConnectionProvider {
 
     /// Fired when the stale connection timer expires
     private func disconnectStaleConnection() {
-        serialConnectionQueue.async {[weak self] in
+        connectionQueue.async {[weak self] in
             guard let self = self else {
                 return
             }

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
@@ -18,7 +18,7 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
     }
 
     public func websocketDidDisconnect(provider: AppSyncWebsocketProvider, error: Error?) {
-        serialConnectionQueue.async { [weak self] in
+        connectionQueue.async { [weak self] in
             guard let self = self else {
                 return
             }
@@ -43,14 +43,18 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
 
     // MARK: - Handle websocket response
 
-    func handleResponse(_ response: RealtimeConnectionProviderResponse) {
+    private func handleResponse(_ response: RealtimeConnectionProviderResponse) {
         resetStaleConnectionTimer()
 
         switch response.responseType {
         case .connectionAck:
-            handleConnectionAck(response: response)
+            connectionQueue.async { [weak self] in
+                self?.handleConnectionAck(response: response)
+            }
         case .error:
-            handleError(response: response)
+            connectionQueue.async { [weak self] in
+                self?.handleError(response: response)
+            }
         case .subscriptionAck, .unsubscriptionAck, .data:
             if let appSyncResponse = response.toAppSyncResponse() {
                 updateCallback(event: .data(appSyncResponse))
@@ -60,6 +64,9 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
         }
     }
 
+    /// Updates connection status callbacks and sets stale connection timeout
+    ///
+    /// - Warning: This method must be invoked on the `connectionQueue`
     private func handleConnectionAck(response: RealtimeConnectionProviderResponse) {
         // Only from in progress state, the connection can transition to connected state.
         // The below guard statement make sure that. If we get connectionAck in other
@@ -67,45 +74,39 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
         guard status == .inProgress else {
             return
         }
-        serialConnectionQueue.async {[weak self] in
-            guard let self = self else {
-                return
-            }
-            self.status = .connected
-            self.updateCallback(event: .connection(self.status))
 
-            // If the service returns a connection timeout, use that instead of the default
-            guard case let .number(value) = response.payload?["connectionTimeoutMs"] else {
-                return
-            }
+        status = .connected
+        updateCallback(event: .connection(status))
 
-            let interval = value / 1_000
-
-            guard interval != self.staleConnectionTimer?.interval else {
-                return
-            }
-
-            AppSyncLogger.debug(
-                """
-                Resetting keep alive timer in response to service timeout \
-                instructions: \(interval)s
-                """
-            )
-            self.staleConnectionTimeout.set(interval)
-            self.startStaleConnectionTimer()
+        // If the service returns a connection timeout, use that instead of the default
+        guard case let .number(value) = response.payload?["connectionTimeoutMs"] else {
+            return
         }
+
+        let interval = value / 1_000
+
+        guard interval != staleConnectionTimer?.interval else {
+            return
+        }
+
+        AppSyncLogger.debug(
+            """
+            Resetting keep alive timer in response to service timeout \
+            instructions: \(interval)s
+            """
+        )
+        staleConnectionTimeout.set(interval)
+        startStaleConnectionTimer()
     }
 
+    /// Resolves & dispatches errors from `response`.
+    ///
+    /// - Warning: This method must be invoked on the `connectionQueue`
     private func handleError(response: RealtimeConnectionProviderResponse) {
         // If we get an error in connection inprogress state, return back as connection error.
-        if status == .inProgress {
-            serialConnectionQueue.async {[weak self] in
-                guard let self = self else {
-                    return
-                }
-                self.status = .notConnected
-                self.updateCallback(event: .error(ConnectionProviderError.connection))
-            }
+        guard status != .inProgress else {
+            status = .notConnected
+            updateCallback(event: .error(ConnectionProviderError.connection))
             return
         }
 

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -10,42 +10,53 @@ import Foundation
 /// Appsync Real time connection that connects to subscriptions
 /// through websocket.
 public class RealtimeConnectionProvider: ConnectionProvider {
+    private let url: URL
+    private var listeners: [String: ConnectionProviderCallback]
 
-    let url: URL
-    var status: ConnectionState = .notConnected
     let websocket: AppSyncWebsocketProvider
-    var listeners: [String: ConnectionProviderCallback] = [:]
-    var messageInterceptors: [MessageInterceptor] = []
-    var connectionInterceptors: [ConnectionInterceptor] = []
+
+    var status: ConnectionState
+    var messageInterceptors: [MessageInterceptor]
+    var connectionInterceptors: [ConnectionInterceptor]
 
     /// Maximum number of seconds a connection may go without receiving a keep alive
     /// message before we consider it stale and force a disconnect
-    let staleConnectionTimeout = AtomicValue<TimeInterval>(initialValue: 5 * 60)
+    let staleConnectionTimeout: AtomicValue<TimeInterval>
 
     /// A timer that automatically disconnects the current connection if it goes longer
     /// than `staleConnectionTimeout` without activity. Receiving any data or "keep
     /// alive" message will cause the timer to be reset to the full interval.
     var staleConnectionTimer: CountdownTimer?
 
-    /// Serial queue for websocket connection.
+    /// Manages concurrency for socket connections, disconnections, writes, and status reports.
     ///
     /// Each connection request will be sent to this queue. Connection request are
     /// handled one at a time.
-    let serialConnectionQueue = DispatchQueue(label: "com.amazonaws.AppSyncRealTimeConnectionProvider.serialQueue")
+    let connectionQueue: DispatchQueue
 
-    let serialCallbackQueue = DispatchQueue(label: "com.amazonaws.AppSyncRealTimeConnectionProvider.callbackQueue")
-
-    let serialWriteQueue = DispatchQueue(label: "com.amazonaws.AppSyncRealTimeConnectionProvider.writeQueue")
+    /// The serial queue on which status & message callbacks from the web socket are invoked.
+    private let serialCallbackQueue = DispatchQueue(
+        label: "com.amazonaws.AppSyncRealTimeConnectionProvider.callbackQueue"
+    )
 
     public init(for url: URL, websocket: AppSyncWebsocketProvider) {
         self.url = url
         self.websocket = websocket
+
+        self.listeners = [:]
+        self.status = .notConnected
+        self.messageInterceptors = []
+        self.connectionInterceptors = []
+        self.staleConnectionTimeout = AtomicValue(initialValue: 5 * 60)
+        self.connectionQueue = DispatchQueue(
+            label: "com.amazonaws.AppSyncRealTimeConnectionProvider.serialQueue"
+        )
     }
 
     // MARK: - ConnectionProvider methods
 
     public func connect() {
-        serialConnectionQueue.async { [weak self] in
+        connectionQueue.async { [weak self] in
             guard let self = self else {
                 return
             }
@@ -69,7 +80,7 @@ public class RealtimeConnectionProvider: ConnectionProvider {
 
     public func write(_ message: AppSyncMessage) {
 
-        serialWriteQueue.async { [weak self] in
+        connectionQueue.async { [weak self] in
             guard let self = self else {
                 return
             }
@@ -98,19 +109,21 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     }
 
     public func disconnect() {
-        websocket.disconnect()
-        staleConnectionTimer?.invalidate()
-        staleConnectionTimer = nil
+        connectionQueue.async {
+            self.websocket.disconnect()
+            self.staleConnectionTimer?.invalidate()
+            self.staleConnectionTimer = nil
+        }
     }
 
     public func addListener(identifier: String, callback: @escaping ConnectionProviderCallback) {
-        serialCallbackQueue.async { [weak self] in
+        connectionQueue.async { [weak self] in
             self?.listeners[identifier] = callback
         }
     }
 
     public func removeListener(identifier: String) {
-        serialCallbackQueue.async { [weak self] in
+        connectionQueue.async { [weak self] in
             guard let self = self else {
                 return
             }
@@ -119,13 +132,8 @@ public class RealtimeConnectionProvider: ConnectionProvider {
 
             if self.listeners.isEmpty {
                 AppSyncLogger.debug("All listeners removed, disconnecting")
-                self.serialConnectionQueue.async { [weak self] in
-                    guard let self = self else {
-                        return
-                    }
-                    self.status = .notConnected
-                    self.disconnect()
-                }
+                self.status = .notConnected
+                self.disconnect()
             }
         }
     }
@@ -136,19 +144,25 @@ public class RealtimeConnectionProvider: ConnectionProvider {
         write(message)
     }
 
+    /// Invokes all registered listeners with `event`. The event is dispatched on `serialCallbackQueue`,
+    /// but internally this method uses the connectionQueue to get the currently registered listeners.
+    ///
+    /// - Parameter event: The connection event to dispatch
     func updateCallback(event: ConnectionProviderEvent) {
-        serialCallbackQueue.async { [weak self] in
-            self?.listeners.values.forEach { $0(event) }
-        }
-    }
-
-    func receivedConnectionInit() {
-        serialConnectionQueue.async { [weak self] in
+        connectionQueue.async { [weak self] in
             guard let self = self else {
                 return
             }
-            self.status = .notConnected
-            self.updateCallback(event: .error(ConnectionProviderError.connection))
+            let allListeners = Array(self.listeners.values)
+            self.serialCallbackQueue.async {
+                allListeners.forEach { $0(event) }
+            }
         }
+    }
+
+    /// - Warning: This must be invoked from the `connectionQueue`
+    private func receivedConnectionInit() {
+        status = .notConnected
+        updateCallback(event: .error(ConnectionProviderError.connection))
     }
 }

--- a/AppSyncRealTimeClient/ConnectionProvider/ConnectionProviderFactory.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/ConnectionProviderFactory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AppSyncRealTimeClient/Support/AppSyncJSONHelper.swift
+++ b/AppSyncRealTimeClient/Support/AppSyncJSONHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AppSyncRealTimeClient/Support/CountdownTimer.swift
+++ b/AppSyncRealTimeClient/Support/CountdownTimer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AppSyncRealTimeClient/Support/SubscriptionConstants.swift
+++ b/AppSyncRealTimeClient/Support/SubscriptionConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
+++ b/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
We received reports of a crash in the StarScreamAdaptor on the line `socket?.write(string: message)`.

Running the integ tests with ThreadSanitizer confirmed my suspicions that the disconnect flow had a race condition: disconnecting sets `socket` to `nil`, which could happen after we check for the existence of `socket` in the null unwrap.

This change:
- Expands use of the connection queue for concurrency protection
- Privatizes a few members of `RealtimeConnectionProvider`
- Normalized initialization to all take place in `init` instead of being spread across `init` and the property declaration
- Adds concurrency protection to the integ test status assertions to avoid spurious race conditions
- Adds the unit tests as a test target of the integ tests so they will always run
- Updates copyright message to new year whereever SwiftFormat happened to catch it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
