### PR TITLE
fix: data races in StarscreamAdapter and ConnectionProvider

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/AppSyncRealTimeClient.xcodeproj/xcshareddata/xcschemes/AppSyncRealTimeClientIntegrationTests.xcscheme
+++ b/AppSyncRealTimeClient.xcodeproj/xcshareddata/xcschemes/AppSyncRealTimeClientIntegrationTests.xcscheme
@@ -39,6 +39,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+Connection.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+Connection.swift
@@ -18,7 +18,7 @@ extension AppSyncSubscriptionConnection {
             return
         }
         if connectionState == .connected {
-            AppSyncLogger.debug("Start subscription")
+            AppSyncLogger.debug("[AppSyncSubscriptionConnection] \(#function): connection is connected, start subscription.")
             startSubscription()
         }
     }
@@ -52,7 +52,7 @@ extension AppSyncSubscriptionConnection {
 
     private func convertToPayload(for query: String, variables: [String: Any?]?) -> AppSyncMessage.Payload? {
         guard let subscriptionItem = subscriptionItem else {
-            AppSyncLogger.debug("\(#function): no subscription item")
+            AppSyncLogger.warn("[AppSyncSubscriptionConnection] \(#function): missing subscription item")
             return nil
         }
 

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+DataHandler.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+DataHandler.swift
@@ -11,12 +11,14 @@ extension AppSyncSubscriptionConnection {
 
     func handleDataEvent(response: AppSyncResponse) {
         guard let subscriptionItem = subscriptionItem else {
-            AppSyncLogger.debug("\(#function): no subscription item")
+            AppSyncLogger.warn("[AppSyncSubscriptionConnection] \(#function): missing subscription item")
             return
         }
 
         guard response.id == subscriptionItem.identifier else {
-            AppSyncLogger.verbose("\(#function): ignoring data event for \(response.id ?? "(null)")")
+            AppSyncLogger.verbose("""
+                [AppSyncSubscriptionConnection] \(#function): \(subscriptionItem.identifier). Ignoring data event for \(response.id ?? "(null)")
+                """)
             return
         }
 

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+ErrorHandler.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+ErrorHandler.swift
@@ -11,7 +11,7 @@ import Starscream
 extension AppSyncSubscriptionConnection {
     func handleError(error: Error) {
         guard let subscriptionItem = subscriptionItem else {
-            AppSyncLogger.debug("\(#function): no subscription item")
+            AppSyncLogger.warn("[AppSyncSubscriptionConnection] \(#function): missing subscription item")
             return
         }
 
@@ -34,7 +34,7 @@ extension AppSyncSubscriptionConnection {
 
         let retryAdvice = retryHandler.shouldRetryRequest(for: connectionError)
         if retryAdvice.shouldRetry, let retryInterval = retryAdvice.retryInterval {
-            AppSyncLogger.debug("Retrying subscription \(subscriptionItem.identifier) after \(retryInterval)")
+            AppSyncLogger.debug("[AppSyncSubscriptionConnection] Retrying subscription \(subscriptionItem.identifier) after \(retryInterval)")
             DispatchQueue.global().asyncAfter(deadline: .now() + retryInterval) {
                 self.connectionProvider?.connect()
             }

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
@@ -50,17 +50,17 @@ public class AppSyncSubscriptionConnection: SubscriptionConnection, RetryableCon
     }
 
     public func unsubscribe(item: SubscriptionItem) {
-        AppSyncLogger.debug("Unsubscribe - \(item.identifier)")
+        AppSyncLogger.debug("[AppSyncSubscriptionConnection] Unsubscribe \(item.identifier)")
 
         let message = AppSyncMessage(id: item.identifier, type: .unsubscribe("stop"))
 
         guard let connectionProvider = connectionProvider else {
-            AppSyncLogger.debug("\(#function): no connection provider")
+            AppSyncLogger.warn("[AppSyncSubscriptionConnection] \(#function): missing connection provider")
             return
         }
 
         guard let subscriptionItem = subscriptionItem else {
-            AppSyncLogger.debug("\(#function): no subscription item")
+            AppSyncLogger.warn("[AppSyncSubscriptionConnection] \(#function): missing subscription item")
             return
         }
 
@@ -70,18 +70,18 @@ public class AppSyncSubscriptionConnection: SubscriptionConnection, RetryableCon
 
     private func addListener() {
         guard let connectionProvider = connectionProvider else {
-            AppSyncLogger.debug("\(#function): no connection provider")
+            AppSyncLogger.warn("[AppSyncSubscriptionConnection] \(#function): no connection provider")
             return
         }
 
         guard let subscriptionItem = subscriptionItem else {
-            AppSyncLogger.debug("\(#function): no subscription item")
+            AppSyncLogger.warn("[AppSyncSubscriptionConnection] \(#function): no subscription item")
             return
         }
 
         connectionProvider.addListener(identifier: subscriptionItem.identifier) { [weak self] event in
             guard let self = self else {
-                AppSyncLogger.debug("Self is nil, listener is not called.")
+                AppSyncLogger.debug("[AppSyncSubscriptionConnection] \(#function): Self is nil, listener is not called.")
                 return
             }
             switch event {

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
@@ -11,7 +11,7 @@ extension RealtimeConnectionProvider {
 
     /// Start a stale connection timer, first invalidating and destroying any existing timer
     func startStaleConnectionTimer() {
-        AppSyncLogger.debug("Starting stale connection timer for \(staleConnectionTimeout.get())s")
+        AppSyncLogger.debug("[RealtimeConnectionProvider] Starting stale connection timer for \(staleConnectionTimeout.get())s")
         if staleConnectionTimer != nil {
             stopStaleConnectionTimer()
         }
@@ -22,14 +22,14 @@ extension RealtimeConnectionProvider {
 
     /// Stop and destroy any existing stale connection timer
     func stopStaleConnectionTimer() {
-        AppSyncLogger.debug("Stopping and destroying stale connection timer")
+        AppSyncLogger.debug("[RealtimeConnectionProvider] Stopping and destroying stale connection timer")
         staleConnectionTimer?.invalidate()
         staleConnectionTimer = nil
     }
 
     /// Reset the stale connection timer in response to receiving a message
     func resetStaleConnectionTimer() {
-        AppSyncLogger.debug("Resetting stale connection timer")
+        AppSyncLogger.debug("[RealtimeConnectionProvider] Resetting stale connection timer")
         staleConnectionTimer?.resetCountdown()
     }
 
@@ -39,9 +39,9 @@ extension RealtimeConnectionProvider {
             guard let self = self else {
                 return
             }
+            AppSyncLogger.error("[RealtimeConnectionProvider] Realtime connection is stale, disconnecting.")
             self.status = .notConnected
             self.websocket.disconnect()
-            AppSyncLogger.error("Realtime connection is stale, disconnected.")
             self.updateCallback(event: .error(ConnectionProviderError.connection))
         }
     }

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
@@ -12,7 +12,7 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
     public func websocketDidConnect(provider: AppSyncWebsocketProvider) {
         // Call the ack to finish the connection handshake
         // Inform the callback when ack gives back a response.
-        AppSyncLogger.debug("WebsocketDidConnect, sending init message...")
+        AppSyncLogger.debug("[RealtimeConnectionProvider] WebsocketDidConnect, sending init message")
         sendConnectionInitMessage()
         startStaleConnectionTimer()
     }
@@ -48,10 +48,12 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
 
         switch response.responseType {
         case .connectionAck:
+            AppSyncLogger.debug("[RealtimeConnectionProvider] received connectionAck")
             connectionQueue.async { [weak self] in
                 self?.handleConnectionAck(response: response)
             }
         case .error:
+            AppSyncLogger.debug("[RealtimeConnectionProvider] received error")
             connectionQueue.async { [weak self] in
                 self?.handleError(response: response)
             }
@@ -60,7 +62,7 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
                 updateCallback(event: .data(appSyncResponse))
             }
         case .keepAlive:
-            AppSyncLogger.debug("\(self) received keepAlive")
+            AppSyncLogger.debug("[RealtimeConnectionProvider] received keepAlive")
         }
     }
 

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -131,9 +131,11 @@ public class RealtimeConnectionProvider: ConnectionProvider {
             self.listeners.removeValue(forKey: identifier)
 
             if self.listeners.isEmpty {
-                AppSyncLogger.debug("All listeners removed, disconnecting")
+                AppSyncLogger.debug("[RealtimeConnectionProvider] all subscriptions removed, disconnecting websocket connection.")
                 self.status = .notConnected
-                self.disconnect()
+                self.websocket.disconnect()
+                self.staleConnectionTimer?.invalidate()
+                self.staleConnectionTimer = nil
             }
         }
     }

--- a/AppSyncRealTimeClient/Interceptor/APIKeyAuthInterceptor.swift
+++ b/AppSyncRealTimeClient/Interceptor/APIKeyAuthInterceptor.swift
@@ -63,7 +63,7 @@ public class APIKeyAuthInterceptor: AuthInterceptor {
             )
             return signedMessage
         default:
-            AppSyncLogger.debug("Message type does not need signing - \(message.messageType)")
+            AppSyncLogger.debug("[APIKeyAuthInterceptor] interceptMessage: No signing required for \(message.messageType)")
         }
         return message
     }

--- a/AppSyncRealTimeClient/Interceptor/OIDCAuthInterceptor.swift
+++ b/AppSyncRealTimeClient/Interceptor/OIDCAuthInterceptor.swift
@@ -37,7 +37,7 @@ public class OIDCAuthInterceptor: AuthInterceptor {
             )
             return signedMessage
         default:
-            AppSyncLogger.debug("Message type does not need signing - \(message.messageType)")
+            AppSyncLogger.debug("[OIDCAuthInterceptor] interceptMessage: No signing required for \(message.messageType)")
         }
         return message
     }

--- a/AppSyncRealTimeClient/Support/AppSyncJSONHelper.swift
+++ b/AppSyncRealTimeClient/Support/AppSyncJSONHelper.swift
@@ -13,7 +13,7 @@ public struct AppSyncJSONHelper {
         let jsonEncoder = JSONEncoder()
         do {
             let jsonHeader = try jsonEncoder.encode(header)
-            AppSyncLogger.verbose("Header - \(String(describing: String(data: jsonHeader, encoding: .utf8)))")
+            AppSyncLogger.verbose("Generated Header for request - \(String(describing: String(data: jsonHeader, encoding: .utf8)))")
             return jsonHeader.base64EncodedString()
         } catch {
             AppSyncLogger.error(error.localizedDescription)

--- a/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter+Delegate.swift
+++ b/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter+Delegate.swift
@@ -12,17 +12,17 @@ import Starscream
 extension StarscreamAdapter: Starscream.WebSocketDelegate {
 
     public func websocketDidConnect(socket: WebSocketClient) {
-        AppSyncLogger.verbose("WebsocketDidConnect")
+        AppSyncLogger.verbose("[StarscreamAdapter] websocketDidConnect: websocket has been connected.")
         delegate?.websocketDidConnect(provider: self)
     }
 
     public func websocketDidDisconnect(socket: WebSocketClient, error: Error?) {
-        AppSyncLogger.verbose("WebsocketDidDisconnect - \(error?.localizedDescription ?? "No error")")
+        AppSyncLogger.verbose("[StarscreamAdapter] websocketDidDisconnect: \(error?.localizedDescription ?? "No error")")
         delegate?.websocketDidDisconnect(provider: self, error: error)
     }
 
     public func websocketDidReceiveMessage(socket: WebSocketClient, text: String) {
-        AppSyncLogger.verbose("WebsocketDidReceiveMessage - \(text)")
+        AppSyncLogger.verbose("[StarscreamAdapter] websocketDidReceiveMessage: - \(text)")
         let data = text.data(using: .utf8) ?? Data()
         delegate?.websocketDidReceiveData(provider: self, data: data)
     }

--- a/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
+++ b/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
@@ -12,30 +12,41 @@ public class StarscreamAdapter: AppSyncWebsocketProvider {
     public init() {
         // Do nothing
     }
-
+    private let serialQueue = DispatchQueue(
+        label: "com.amazonaws.StarscreamAdapter.serialQueue"
+    )
     var socket: WebSocket?
     weak var delegate: AppSyncWebsocketDelegate?
 
     public func connect(url: URL, protocols: [String], delegate: AppSyncWebsocketDelegate?) {
-        AppSyncLogger.verbose("Connecting to url ...")
-        socket = WebSocket(url: url, protocols: protocols)
-        self.delegate = delegate
-        socket?.delegate = self
-        socket?.callbackQueue = DispatchQueue(label: "com.amazonaws.StarscreamAdapter.callBack")
-        socket?.connect()
+        serialQueue.async {
+            AppSyncLogger.verbose("[StarscreamAdapter] connect. Connecting to url")
+            self.socket = WebSocket(url: url, protocols: protocols)
+            self.delegate = delegate
+            self.socket?.delegate = self
+            self.socket?.callbackQueue = DispatchQueue(label: "com.amazonaws.StarscreamAdapter.callBack")
+            self.socket?.connect()
+        }
     }
 
     public func disconnect() {
-        socket?.disconnect()
-        socket = nil
+        serialQueue.async {
+            AppSyncLogger.verbose("[StarscreamAdapter] socket.disconnect")
+            self.socket?.disconnect()
+            self.socket = nil
+        }
     }
 
     public func write(message: String) {
-        AppSyncLogger.verbose("Websocket write - \(message)")
-        socket?.write(string: message)
+        serialQueue.async {
+            AppSyncLogger.verbose("[StarscreamAdapter] socket.write - \(message)")
+            self.socket?.write(string: message)
+        }
     }
 
     public var isConnected: Bool {
-        return socket?.isConnected ?? false
+        serialQueue.sync {
+            return socket?.isConnected ?? false
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes two race conditions. The scenario is to create many subscriptions, unsubscribe, and repeat.

Recall that, when the last subscription is unsubscribed, the websocket connection is also disconnected. For example, make 3 subscriptions, and unsubscribe from each one, on the last unsubscribe, the websocket will be disconnected asynchronously. This has introduced a problem in many ways.

1. Websocket is being disconnected while a subscription is being created and socket is being connected, there's data race in `StarscreamAdapter` which operates on the underlying Starscream websocket `socket` object when perform websocket operations. See Issue log 1 of the data race. The fix added in this PR is to operate under a serial queue.

2. The last subscription is unsubscribed, which kicks off a `websocket.disconnect` asynchronsouly, a new subscription is being created and socket is being connected. `socket.conect()` is called from `StarscreamAdapter`, followed by the `socket.disconnect()`, StarscreamAdapter never receives the `websocketDidConnect` callback. See Issue log 2.

Issue log 1
```
UMMARY: ThreadSanitizer: data race <compiler-generated> in StarscreamAdapter.socket.setter
==================
ThreadSanitizer report breakpoint hit. Use 'thread info -s' to get extended information about the report.
==================
WARNING: ThreadSanitizer: data race (pid=46416)
  Read of size 8 at 0x7b0c0005e8a0 by thread T6:
    #0 StarscreamAdapter.socket.setter <compiler-generated> (AppSyncRealTimeClient:x86_64+0x4588c)
    #1 StarscreamAdapter.disconnect() StarscreamAdapter.swift:30 (AppSyncRealTimeClient:x86_64+0x46948)
    #2 protocol witness for AppSyncWebsocketProvider.disconnect() in conformance StarscreamAdapter <compiler-generated> (AppSyncRealTimeClient:x86_64+0x47280)
    #3 closure #1 in RealtimeConnectionProvider.disconnect() RealtimeConnectionProvider.swift:113 (AppSyncRealTimeClient:x86_64+0x1a66e)
    #4 partial apply for closure #1 in RealtimeConnectionProvider.disconnect() <compiler-generated> (AppSyncRealTimeClient:x86_64+0x1a7fd)
    #5 thunk for @escaping @callee_guaranteed () -> () <compiler-generated> (AppSyncRealTimeClient:x86_64+0x15593)
    #6 __tsan::invoke_and_release_block(void*) <null>:2 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x70ebb)
    #7 _dispatch_client_callout <null>:2 (libdispatch.dylib:x86_64+0x3507)

  Previous write of size 8 at 0x7b0c0005e8a0 by thread T4:
    #0 StarscreamAdapter.socket.setter <compiler-generated> (AppSyncRealTimeClient:x86_64+0x458a4)
    #1 StarscreamAdapter.connect(url:protocols:delegate:) StarscreamAdapter.swift:21 (AppSyncRealTimeClient:x86_64+0x4626a)
    #2 protocol witness for AppSyncWebsocketProvider.connect(url:protocols:delegate:) in conformance StarscreamAdapter <compiler-generated> (AppSyncRealTimeClient:x86_64+0x471ef)
    #3 closure #1 in closure #1 in RealtimeConnectionProvider.connect() RealtimeConnectionProvider.swift:72 (AppSyncRealTimeClient:x86_64+0x18fc1)
    #4 partial apply for closure #1 in closure #1 in RealtimeConnectionProvider.connect() <compiler-generated> (AppSyncRealTimeClient:x86_64+0x1e7db)
    #5 thunk for @escaping @callee_guaranteed () -> () <compiler-generated> (AppSyncRealTimeClient:x86_64+0x15593)
    #6 __tsan::invoke_and_release_block(void*) <null>:2 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x70ebb)
    #7 _dispatch_client_callout <null>:2 (libdispatch.dylib:x86_64+0x3507)

  Location is heap block of size 40 at 0x7b0c0005e890 allocated by main thread:
    #0 __sanitizer_mz_malloc <null>:2 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x4f29a)
    #1 _malloc_zone_malloc <null>:2 (libsystem_malloc.dylib:x86_64+0x129cf)
    #2 static ConnectionProviderFactory.createConnectionProvider(for:connectionType:) ConnectionProviderFactory.swift:37 (AppSyncRealTimeClient:x86_64+0x141bd)
    #3 static ConnectionProviderFactory.createConnectionProvider(for:authInterceptor:connectionType:) ConnectionProviderFactory.swift:18 (AppSyncRealTimeClient:x86_64+0x13a85)
    #4 AppSyncRealTimeClientIntegrationTests.testAllSubscriptionsCancelledShouldDisconnectTheWebsocket() AppSyncRealTimeClientIntegrationTests.swift:222 (AppSyncRealTimeClientIntegrationTests:x86_64+0xd73b)
    #5 @objc AppSyncRealTimeClientIntegrationTests.testAllSubscriptionsCancelledShouldDisconnectTheWebsocket() <compiler-generated> (AppSyncRealTimeClientIntegrationTests:x86_64+0xe0e4)
    #6 __invoking___ <null>:2 (CoreFoundation:x86_64+0x1182fb)
    #7 start <null>:2 (libdyld.dylib:x86_64+0x13e8)

  Thread T6 (tid=4498026, running) is a GCD worker thread

  Thread T4 (tid=4498023, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: data race <compiler-generated> in StarscreamAdapter.socket.setter
```

Issue log 2
```
2021-04-27 16:20:52.283606-0700 HostApp[55672:4633119] [RealtimeConnectionProvider] all subscriptions removed, disconnecting websocket connection.
2021-04-27 16:20:52.283612-0700 HostApp[55672:4633211] [StarscreamAdapter] socket.write - {"id":"FF0D349A-2D63-4F74-A864-F1FFE127C00A","type":"stop"}
2021-04-27 16:20:52.284517-0700 HostApp[55672:4633119] Generated Header for request - Optional("{\"x-amz-date\":\"20210427T232052Z\",\"x-api-key\":\"da2-xxxxx\",\"host\":\"xxxx.appsync-api.us-west-2.amazonaws.com\"}")
2021-04-27 16:20:52.284788-0700 HostApp[55672:4633115] [StarscreamAdapter] connect. Connecting to url
2021-04-27 16:20:52.286637-0700 HostApp[55672:4633115] [StarscreamAdapter] socket.disconnect
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
