### PR TITLE
feat: Attempt to reconnect on connectivity

### DIFF
--- a/AppSyncRealTimeClient.xcodeproj/project.pbxproj
+++ b/AppSyncRealTimeClient.xcodeproj/project.pbxproj
@@ -45,6 +45,9 @@
 		217F39F12406EA4000F1A0B3 /* MockConnectionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217F39EB2406EA3F00F1A0B3 /* MockConnectionProvider.swift */; };
 		217F39F22406EA4000F1A0B3 /* ConnectionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217F39ED2406EA4000F1A0B3 /* ConnectionProviderTests.swift */; };
 		217F39F32406EA4000F1A0B3 /* RealtimeGatewayURLInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217F39EF2406EA4000F1A0B3 /* RealtimeGatewayURLInterceptorTests.swift */; };
+		219BFF3B27A38902000FC148 /* schema.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 219BFF3A27A38902000FC148 /* schema.graphql */; };
+		219BFF4927A3B238000FC148 /* ConnectivityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219BFF4827A3B237000FC148 /* ConnectivityMonitor.swift */; };
+		219BFF4B27A3B24F000FC148 /* ConnectivityPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219BFF4A27A3B24F000FC148 /* ConnectivityPath.swift */; };
 		21D38B412409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D38B402409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests.swift */; };
 		21D38B432409AFBD00EC2A8D /* AppSyncRealTimeClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 217F398F2405D9D500F1A0B3 /* AppSyncRealTimeClient.framework */; };
 		21D38B4C2409B6C000EC2A8D /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21D38B4B2409B6C000EC2A8D /* amplifyconfiguration.json */; };
@@ -165,6 +168,9 @@
 		217F39EB2406EA3F00F1A0B3 /* MockConnectionProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockConnectionProvider.swift; sourceTree = "<group>"; };
 		217F39ED2406EA4000F1A0B3 /* ConnectionProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionProviderTests.swift; sourceTree = "<group>"; };
 		217F39EF2406EA4000F1A0B3 /* RealtimeGatewayURLInterceptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealtimeGatewayURLInterceptorTests.swift; sourceTree = "<group>"; };
+		219BFF3A27A38902000FC148 /* schema.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = schema.graphql; sourceTree = "<group>"; };
+		219BFF4827A3B237000FC148 /* ConnectivityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMonitor.swift; sourceTree = "<group>"; };
+		219BFF4A27A3B24F000FC148 /* ConnectivityPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityPath.swift; sourceTree = "<group>"; };
 		21D38B3E2409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppSyncRealTimeClientIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21D38B402409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientIntegrationTests.swift; sourceTree = "<group>"; };
 		21D38B422409AFBD00EC2A8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -309,6 +315,7 @@
 				2143D4AF27BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift */,
 				217F39B82406E98300F1A0B3 /* Connection */,
 				217F39A92406E98300F1A0B3 /* ConnectionProvider */,
+				219BFF4727A3B223000FC148 /* ConnectivityMonitor */,
 				217F39932405D9D500F1A0B3 /* Info.plist */,
 				21D38B6E240A272F00EC2A8D /* Interceptor */,
 				217F39C62406E98400F1A0B3 /* Support */,
@@ -453,6 +460,15 @@
 			path = Support;
 			sourceTree = "<group>";
 		};
+		219BFF4727A3B223000FC148 /* ConnectivityMonitor */ = {
+			isa = PBXGroup;
+			children = (
+				219BFF4827A3B237000FC148 /* ConnectivityMonitor.swift */,
+				219BFF4A27A3B24F000FC148 /* ConnectivityPath.swift */,
+			);
+			path = ConnectivityMonitor;
+			sourceTree = "<group>";
+		};
 		21D38B3F2409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -514,6 +530,7 @@
 		21D38B95240C4DC200EC2A8D /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				219BFF3A27A38902000FC148 /* schema.graphql */,
 				21D38B98240C4E1C00EC2A8D /* ConfigurationHelper.swift */,
 				21D38B96240C4DCF00EC2A8D /* Error+Extension.swift */,
 				21D38B9C240C540D00EC2A8D /* TestCommonConstants.swift */,
@@ -770,6 +787,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				21D38B4E2409B8B200EC2A8D /* README.md in Resources */,
+				219BFF3B27A38902000FC148 /* schema.graphql in Resources */,
 				21D38B4C2409B6C000EC2A8D /* amplifyconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1120,6 +1138,7 @@
 				217F39CD2406E98400F1A0B3 /* InterceptableConnection.swift in Sources */,
 				21D38B8E240A3C2300EC2A8D /* ConnectionProviderFactory.swift in Sources */,
 				217F39E02406E98400F1A0B3 /* AppSyncWebsocketProvider.swift in Sources */,
+				219BFF4927A3B238000FC148 /* ConnectivityMonitor.swift in Sources */,
 				FAB7E91224D2644E00DF1EA1 /* RealtimeConnectionProvider+StaleConnection.swift in Sources */,
 				217F39D32406E98400F1A0B3 /* RealtimeConnectionProvider.swift in Sources */,
 				217F39D12406E98400F1A0B3 /* AppSyncConnectionRequest.swift in Sources */,
@@ -1144,6 +1163,7 @@
 				217F39D42406E98400F1A0B3 /* RealtimeConnectionProvider+Websocket.swift in Sources */,
 				217F39DC2406E98400F1A0B3 /* AppSyncSubscriptionConnection.swift in Sources */,
 				21D38B6D240A262800EC2A8D /* AppSyncJSONHelper.swift in Sources */,
+				219BFF4B27A3B24F000FC148 /* ConnectivityPath.swift in Sources */,
 				217F39CE2406E98400F1A0B3 /* ConnectionProviderError.swift in Sources */,
 				217F39E12406E98400F1A0B3 /* StarscreamAdapter.swift in Sources */,
 				217F39D72406E98400F1A0B3 /* RealtimeConnectionProvider+ConnectionInterceptable.swift in Sources */,

--- a/AppSyncRealTimeClient.xcodeproj/project.pbxproj
+++ b/AppSyncRealTimeClient.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		219BFF3B27A38902000FC148 /* schema.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 219BFF3A27A38902000FC148 /* schema.graphql */; };
 		219BFF4927A3B238000FC148 /* ConnectivityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219BFF4827A3B237000FC148 /* ConnectivityMonitor.swift */; };
 		219BFF4B27A3B24F000FC148 /* ConnectivityPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219BFF4A27A3B24F000FC148 /* ConnectivityPath.swift */; };
+		219BFF6A27A9AC6E000FC148 /* ConnectivityMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219BFF6927A9AC6E000FC148 /* ConnectivityMonitorTests.swift */; };
+		219BFF6C27A9AF85000FC148 /* MockConnectivityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219BFF6B27A9AF85000FC148 /* MockConnectivityMonitor.swift */; };
 		21D38B412409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D38B402409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests.swift */; };
 		21D38B432409AFBD00EC2A8D /* AppSyncRealTimeClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 217F398F2405D9D500F1A0B3 /* AppSyncRealTimeClient.framework */; };
 		21D38B4C2409B6C000EC2A8D /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21D38B4B2409B6C000EC2A8D /* amplifyconfiguration.json */; };
@@ -171,6 +173,8 @@
 		219BFF3A27A38902000FC148 /* schema.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = schema.graphql; sourceTree = "<group>"; };
 		219BFF4827A3B237000FC148 /* ConnectivityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMonitor.swift; sourceTree = "<group>"; };
 		219BFF4A27A3B24F000FC148 /* ConnectivityPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityPath.swift; sourceTree = "<group>"; };
+		219BFF6927A9AC6E000FC148 /* ConnectivityMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMonitorTests.swift; sourceTree = "<group>"; };
+		219BFF6B27A9AF85000FC148 /* MockConnectivityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConnectivityMonitor.swift; sourceTree = "<group>"; };
 		21D38B3E2409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppSyncRealTimeClientIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21D38B402409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientIntegrationTests.swift; sourceTree = "<group>"; };
 		21D38B422409AFBD00EC2A8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -329,6 +333,7 @@
 			children = (
 				217F39E82406EA3F00F1A0B3 /* Connection */,
 				217F39EC2406EA4000F1A0B3 /* ConnectionProvider */,
+				219BFF6827A9AC4F000FC148 /* ConnectivityMonitor */,
 				217F399F2405D9D500F1A0B3 /* Info.plist */,
 				21D38B84240A39E400EC2A8D /* Interceptor */,
 				217F39EA2406EA3F00F1A0B3 /* Mocks */,
@@ -436,6 +441,7 @@
 			children = (
 				217F39EB2406EA3F00F1A0B3 /* MockConnectionProvider.swift */,
 				FA67507724D3244A005A1345 /* MockWebsocketProvider.swift */,
+				219BFF6B27A9AF85000FC148 /* MockConnectivityMonitor.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -465,6 +471,14 @@
 			children = (
 				219BFF4827A3B237000FC148 /* ConnectivityMonitor.swift */,
 				219BFF4A27A3B24F000FC148 /* ConnectivityPath.swift */,
+			);
+			path = ConnectivityMonitor;
+			sourceTree = "<group>";
+		};
+		219BFF6827A9AC4F000FC148 /* ConnectivityMonitor */ = {
+			isa = PBXGroup;
+			children = (
+				219BFF6927A9AC6E000FC148 /* ConnectivityMonitorTests.swift */,
 			);
 			path = ConnectivityMonitor;
 			sourceTree = "<group>";
@@ -1176,6 +1190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				21D38B89240A39E400EC2A8D /* OIDCAuthInterceptorTests.swift in Sources */,
+				219BFF6C27A9AF85000FC148 /* MockConnectivityMonitor.swift in Sources */,
 				217F39F22406EA4000F1A0B3 /* ConnectionProviderTests.swift in Sources */,
 				2143D46727B5D9B40066B2F7 /* RealTimeConnectionProviderResponseTests.swift in Sources */,
 				FA67507824D3244A005A1345 /* MockWebsocketProvider.swift in Sources */,
@@ -1185,6 +1200,7 @@
 				21D38B8B240A39E400EC2A8D /* AppSyncJSONHelperTests.swift in Sources */,
 				217F39F32406EA4000F1A0B3 /* RealtimeGatewayURLInterceptorTests.swift in Sources */,
 				FA67507E24D33976005A1345 /* RealtimeConnectionProviderTestBase.swift in Sources */,
+				219BFF6A27A9AC6E000FC148 /* ConnectivityMonitorTests.swift in Sources */,
 				978409BA2739C7E1002362A7 /* AppSyncURLHelperTests.swift in Sources */,
 				FA67508424D33ACC005A1345 /* CountdownTimerTests.swift in Sources */,
 				FA67508024D339B0005A1345 /* ConnectionProviderStaleConnectionTests.swift in Sources */,

--- a/AppSyncRealTimeClient.xcodeproj/xcshareddata/xcschemes/AppSyncRealTimeClient.xcscheme
+++ b/AppSyncRealTimeClient.xcodeproj/xcshareddata/xcschemes/AppSyncRealTimeClient.xcscheme
@@ -45,6 +45,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
@@ -43,10 +43,7 @@ extension RealtimeConnectionProvider {
 
             } else if self.status == .connected && self.isStaleConnection && connectivity.status == .satisfied {
                 AppSyncLogger.debug("[RealtimeConnectionProvider] Connetion is stale. Disconnecting to begin reconnect.")
-                if self.staleConnectionTimer != nil {
-                    self.stopStaleConnectionTimer()
-                }
-
+                self.staleConnectionTimer.invalidate()
                 self.disconnectStaleConnection()
             }
         }

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
@@ -30,6 +30,28 @@ extension RealtimeConnectionProvider {
         staleConnectionTimer.invalidate()
     }
 
+    /// Handle updates from the ConnectivityMonitor
+    func handleConnectivityUpdates(connectivity: ConnectivityPath) {
+        connectionQueue.async {[weak self] in
+            guard let self = self else {
+                return
+            }
+            AppSyncLogger.debug("[RealtimeConnectionProvider] Status: \(self.status). Connectivity status: \(connectivity.status)")
+            if self.status == .connected && connectivity.status == .unsatisfied && !self.isStaleConnection {
+                AppSyncLogger.debug("[RealtimeConnectionProvider] Connetion is stale. Pending reconnect on connectivity.")
+                self.isStaleConnection = true
+
+            } else if self.status == .connected && self.isStaleConnection && connectivity.status == .satisfied {
+                AppSyncLogger.debug("[RealtimeConnectionProvider] Connetion is stale. Disconnecting to begin reconnect.")
+                if self.staleConnectionTimer != nil {
+                    self.stopStaleConnectionTimer()
+                }
+
+                self.disconnectStaleConnection()
+            }
+        }
+    }
+
     /// Fired when the stale connection timer expires
     private func disconnectStaleConnection() {
         connectionQueue.async {[weak self] in
@@ -38,9 +60,9 @@ extension RealtimeConnectionProvider {
             }
             AppSyncLogger.error("[RealtimeConnectionProvider] Realtime connection is stale, disconnecting.")
             self.status = .notConnected
+            self.isStaleConnection = false
             self.websocket.disconnect()
             self.updateCallback(event: .error(ConnectionProviderError.connection))
         }
     }
-
 }

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -28,11 +28,17 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     /// alive" message will cause the timer to be reset to the full interval.
     var staleConnectionTimer: CountdownTimer
 
+    /// Intermediate state when the connection is connected and connectivity updates to unsatisfied (offline)
+    var isStaleConnection: Bool
+
     /// Manages concurrency for socket connections, disconnections, writes, and status reports.
     ///
     /// Each connection request will be sent to this queue. Connection request are
     /// handled one at a time.
     let connectionQueue: DispatchQueue
+
+    /// Monitor for connectivity updates to disconnect the current connection if it flips between connectivity statuses
+    let connectivityMonitor: ConnectivityMonitor
 
     /// The serial queue on which status & message callbacks from the web socket are invoked.
     private let serialCallbackQueue = DispatchQueue(
@@ -51,6 +57,11 @@ public class RealtimeConnectionProvider: ConnectionProvider {
         self.connectionQueue = DispatchQueue(
             label: "com.amazonaws.AppSyncRealTimeConnectionProvider.serialQueue"
         )
+        self.isStaleConnection = false
+        self.connectivityMonitor = ConnectivityMonitor()
+        if #available(iOS 12.0, *) {
+            self.connectivityMonitor.start(conectivityUpdates: handleConnectivityUpdates(connectivity:))
+        }
     }
 
     // MARK: - ConnectionProvider methods

--- a/AppSyncRealTimeClient/ConnectivityMonitor/ConnectivityMonitor.swift
+++ b/AppSyncRealTimeClient/ConnectivityMonitor/ConnectivityMonitor.swift
@@ -47,9 +47,6 @@ class ConnectivityMonitor {
         guard let monitor = monitor else {
             return
         }
-        defer {
-            self.monitor = nil
-        }
         monitor.cancel()
     }
 

--- a/AppSyncRealTimeClient/ConnectivityMonitor/ConnectivityMonitor.swift
+++ b/AppSyncRealTimeClient/ConnectivityMonitor/ConnectivityMonitor.swift
@@ -47,6 +47,9 @@ class ConnectivityMonitor {
         guard let monitor = monitor else {
             return
         }
+        defer {
+            self.monitor = nil
+        }
         monitor.cancel()
     }
 

--- a/AppSyncRealTimeClient/ConnectivityMonitor/ConnectivityMonitor.swift
+++ b/AppSyncRealTimeClient/ConnectivityMonitor/ConnectivityMonitor.swift
@@ -1,0 +1,85 @@
+//
+// Copyright 2018-2021 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Network
+
+typealias ConnectivityUpdates = (ConnectivityPath) -> Void
+
+protocol AnyConnectivityMonitor {
+    func start(connectivityUpdatesQueue: DispatchQueue, onConectivityUpdates: @escaping ConnectivityUpdates)
+    func cancel()
+}
+
+class ConnectivityMonitor {
+    var connectivity: ConnectivityPath?
+
+    private let connectivityUpdatesQueue = DispatchQueue(
+        label: "com.amazonaws.ConnectivityMonitor.connectivityUpdatesQueue",
+        qos: .background
+    )
+    private var monitor: AnyConnectivityMonitor?
+
+    init() {
+    }
+
+    @available(iOS 12.0, *)
+    func start(conectivityUpdates: @escaping ConnectivityUpdates) {
+        let monitor = NetworkMonitor()
+        self.monitor = monitor
+        monitor.start(connectivityUpdatesQueue: connectivityUpdatesQueue, onConectivityUpdates: conectivityUpdates)
+    }
+
+    func cancel() {
+        guard let monitor = monitor else {
+            return
+        }
+        monitor.cancel()
+        self.monitor = nil
+    }
+
+    deinit {
+        cancel()
+    }
+}
+
+@available(iOS 12.0, macOS 10.14, tvOS 12.0, watchOS 6.0, *)
+class NetworkMonitor: AnyConnectivityMonitor {
+    private var monitor: NWPathMonitor?
+    private var onConectivityUpdates: ConnectivityUpdates?
+    private var connectivityUpdatesQueue: DispatchQueue?
+    private let queue = DispatchQueue(label: "com.amazonaws.NetworkMonitor.queue", qos: .background)
+
+    func start(connectivityUpdatesQueue: DispatchQueue, onConectivityUpdates: @escaping ConnectivityUpdates) {
+        self.connectivityUpdatesQueue = connectivityUpdatesQueue
+        self.onConectivityUpdates = onConectivityUpdates
+        // A new instance is required each time a monitor is started
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = didUpdate(path:)
+        monitor.start(queue: queue)
+        self.monitor = monitor
+    }
+
+    func cancel() {
+        guard let monitor = monitor else { return }
+        defer {
+            self.monitor = nil
+        }
+        monitor.cancel()
+    }
+
+    func didUpdate(path: NWPath) {
+        guard let onConectivityUpdates = onConectivityUpdates,
+              let connectivityUpdatesQueue = connectivityUpdatesQueue else {
+            return
+        }
+        let connectivityPath = ConnectivityPath(path: path)
+        connectivityUpdatesQueue.async {
+            onConectivityUpdates(connectivityPath)
+        }
+    }
+}

--- a/AppSyncRealTimeClient/ConnectivityMonitor/ConnectivityPath.swift
+++ b/AppSyncRealTimeClient/ConnectivityMonitor/ConnectivityPath.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectivityMonitor/ConnectivityPath.swift
+++ b/AppSyncRealTimeClient/ConnectivityMonitor/ConnectivityPath.swift
@@ -1,0 +1,125 @@
+//
+// Copyright 2018-2021 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Network
+
+struct ConnectivityPath {
+    let status: ConnectivityStatus
+    let availableInterfaces: [ConnectivityInterface]
+    let isExpensive: Bool
+    let supportsDNS: Bool
+    let supportsIPv4: Bool
+    let supportsIPv6: Bool
+
+    init(
+        status: ConnectivityStatus = .unsatisfied,
+        availableInterfaces: [ConnectivityInterface] = [],
+        isExpensive: Bool = false,
+        supportsDNS: Bool = false,
+        supportsIPv4: Bool = false,
+        supportsIPv6: Bool = false
+    ) {
+        self.status = status
+        self.availableInterfaces = availableInterfaces
+        self.isExpensive = isExpensive
+        self.supportsDNS = supportsDNS
+        self.supportsIPv4 = supportsIPv4
+        self.supportsIPv6 = supportsIPv6
+    }
+}
+
+extension ConnectivityPath: CustomStringConvertible {
+    var description: String {
+        [
+            "\(status): \(availableInterfaces.description)",
+            "Expensive = \(isExpensive ? "YES" : "NO")",
+            "DNS = \(supportsDNS ? "YES" : "NO")",
+            "IPv4 = \(supportsIPv4 ? "YES" : "NO")",
+            "IPv6 = \(supportsIPv6 ? "YES" : "NO")"
+        ].joined(separator: "; ")
+    }
+}
+
+extension ConnectivityPath {
+    @available(iOS 12.0, *)
+    init(path: NWPath) {
+        self.status = ConnectivityStatus(status: path.status)
+        self.availableInterfaces = path.availableInterfaces.map { ConnectivityInterface(interface: $0) }
+        self.isExpensive = path.isExpensive
+        self.supportsDNS = path.supportsDNS
+        self.supportsIPv4 = path.supportsIPv4
+        self.supportsIPv6 = path.supportsIPv6
+    }
+}
+
+enum ConnectivityInterfaceType: String {
+    case other
+    case wifi
+    case cellular
+    case wiredEthernet
+    case loopback
+}
+
+extension ConnectivityInterfaceType {
+    @available(iOS 12.0, *)
+    init(interfaceType: NWInterface.InterfaceType) {
+        switch interfaceType {
+        case .other:
+            self = .other
+        case .wifi:
+            self = .wifi
+        case .cellular:
+            self = .cellular
+        case .wiredEthernet:
+            self = .wiredEthernet
+        case .loopback:
+            self = .loopback
+        @unknown default:
+            self = .other
+        }
+    }
+}
+
+struct ConnectivityInterface {
+    public let name: String
+    public let type: ConnectivityInterfaceType
+
+    public init(name: String, type: ConnectivityInterfaceType) {
+        self.name = name
+        self.type = type
+    }
+}
+extension ConnectivityInterface {
+    @available(iOS 12.0, *)
+    init(interface: NWInterface) {
+        self.name = interface.name
+        self.type = ConnectivityInterfaceType(interfaceType: interface.type)
+    }
+}
+
+enum ConnectivityStatus: String {
+    case satisfied
+    case unsatisfied
+    case requiresConnection
+}
+
+extension ConnectivityStatus {
+    @available(iOS 12.0, *)
+    init(status: NWPath.Status) {
+        switch status {
+        case .satisfied:
+            self = .satisfied
+        case .unsatisfied:
+            self = .unsatisfied
+        case .requiresConnection:
+            self = .requiresConnection
+        @unknown default:
+            self = .unsatisfied
+        }
+    }
+}

--- a/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderStaleConnectionTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderStaleConnectionTests.swift
@@ -62,4 +62,88 @@ class ConnectionProviderStaleConnectionTests: RealtimeConnectionProviderTestBase
         waitForExpectations(timeout: 0.05)
     }
 
+    /// Given a connected websocket, when the network status toggles to disconnected and back to connected,
+    /// the connecion should be disconnected with `error`.
+    /// Note: This error is handled by the subscriptions to attempt to reconnect the websocket.
+    ///
+    /// - Given: Connected websocket
+    /// - When:
+    ///    - Connectivity updates to unsatisfied (network is down)
+    ///    - Connectivity updates to satisfied (network is back up)
+    /// - Then:
+    ///    - Websocket is disconnected
+    func testConnectionDisconnectsAfterConnectivityUpdates() {
+        receivedNotConnected.isInverted = true
+        receivedError.isInverted = true
+
+        let onConnect: MockWebsocketProvider.OnConnect = { _, _, delegate in
+            self.websocketDelegate = delegate
+            DispatchQueue.global().async {
+                delegate?.websocketDidConnect(provider: self.websocket)
+            }
+        }
+
+        let onDisconnect: MockWebsocketProvider.OnDisconnect = { }
+
+        let onWrite: MockWebsocketProvider.OnWrite = { message in
+            guard RealtimeConnectionProviderTestBase.messageType(of: message, equals: "connection_init") else {
+                XCTFail("Incoming message did not have 'connection_init' type")
+                return
+            }
+
+            self.websocketDelegate.websocketDidReceiveData(
+                provider: self.websocket,
+                data: RealtimeConnectionProviderTestBase.makeConnectionAckMessage()
+            )
+        }
+
+        websocket = MockWebsocketProvider(
+            onConnect: onConnect,
+            onDisconnect: onDisconnect,
+            onWrite: onWrite
+        )
+        let connectionQueue = DispatchQueue(
+            label: "com.amazonaws.ConnectionProviderStaleConnectionTests.connectionQueue")
+
+        let monitor = MockConnectivityMonitor()
+        let connectivityMonitor = ConnectivityMonitor(monitor: monitor)
+
+        // Retain the provider so it doesn't release prior to executing callbacks
+        let provider = createProviderAndConnect(
+            listeners: nil,
+            connectionQueue: connectionQueue,
+            connectivityMonitor: connectivityMonitor
+        )
+
+        // Wait for websocket to be connected
+        waitForExpectations(timeout: 0.05)
+
+        // Send connectivity update - network down
+        monitor.sendConnectivityUpdate(.init(status: .unsatisfied))
+        let connectionIsStale = expectation(description: "connection is stale")
+        connectionQueue.asyncAfter(deadline: .now() + 0.5) {
+            XCTAssertTrue(provider.isStaleConnection)
+            connectionIsStale.fulfill()
+        }
+        wait(for: [connectionIsStale], timeout: 1.0)
+
+        // Send connectivity update - network up
+        let receivedError = expectation(description: "listeners receive error event")
+        provider.addListener(identifier: "id") { event in
+            guard case .error = event else {
+                XCTFail("Event should be error")
+                return
+            }
+            receivedError.fulfill()
+        }
+        monitor.sendConnectivityUpdate(.init(status: .satisfied))
+        let connectionIsDisconnected = expectation(description: "connection is disconnected")
+        connectionQueue.asyncAfter(deadline: .now() + 0.5) {
+            XCTAssertFalse(provider.isStaleConnection)
+            XCTAssertTrue(provider.status == .notConnected)
+            XCTAssertNil(provider.staleConnectionTimer)
+            connectionIsDisconnected.fulfill()
+        }
+        wait(for: [connectionIsDisconnected, receivedError], timeout: 1.0)
+    }
 }

--- a/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderStaleConnectionTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderStaleConnectionTests.swift
@@ -141,7 +141,6 @@ class ConnectionProviderStaleConnectionTests: RealtimeConnectionProviderTestBase
         connectionQueue.asyncAfter(deadline: .now() + 0.5) {
             XCTAssertFalse(provider.isStaleConnection)
             XCTAssertTrue(provider.status == .notConnected)
-            XCTAssertNil(provider.staleConnectionTimer)
             connectionIsDisconnected.fulfill()
         }
         wait(for: [connectionIsDisconnected, receivedError], timeout: 1.0)

--- a/AppSyncRealTimeClientTests/ConnectionProvider/RealtimeConnectionProviderTestBase.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/RealtimeConnectionProviderTestBase.swift
@@ -39,8 +39,19 @@ class RealtimeConnectionProviderTestBase: XCTestCase {
     ///
     /// Preconditions:
     /// - `self.websocket` must be initialized in the mock provider's `onConnect`
-    func createProviderAndConnect(listeners: [String]? = nil) -> RealtimeConnectionProvider {
-        let provider = RealtimeConnectionProvider(for: url, websocket: websocket)
+    func createProviderAndConnect(
+        listeners: [String]? = nil,
+        connectionQueue: DispatchQueue = DispatchQueue(label: "com.amazonaws.RealtimeConnectionProviderTestBase.connectionQueue"),
+        serialCallbackQueue: DispatchQueue = DispatchQueue(label: "com.amazonaws.RealtimeConnectionProviderTestBase.serialCallbackQueue"),
+        connectivityMonitor: ConnectivityMonitor = ConnectivityMonitor()
+    ) -> RealtimeConnectionProvider {
+        let provider = RealtimeConnectionProvider(
+            url: url,
+            websocket: websocket,
+            connectionQueue: connectionQueue,
+            serialCallbackQueue: serialCallbackQueue,
+            connectivityMonitor: connectivityMonitor
+        )
         provider.addListener(identifier: "testListener") { event in
             switch event {
             case .connection(let connectionState):

--- a/AppSyncRealTimeClientTests/ConnectivityMonitor/ConnectivityMonitorTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectivityMonitor/ConnectivityMonitorTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/ConnectivityMonitor/ConnectivityMonitorTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectivityMonitor/ConnectivityMonitorTests.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2018-2021 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import AppSyncRealTimeClient
+import Network
+
+class ConnectivityMonitorTests: XCTestCase {
+
+    /// Test `NetworkMonitor` that uses `NWPathMonitor`
+    /// Only assert that the connectivity update isn't `nil` since the status is based on the conditions
+    /// of when test is run.
+    func testNetworkMonitor() {
+        let connectivityUpdateReceived = expectation(description: "connectivity update received")
+        let monitor = ConnectivityMonitor(monitor: nil)
+        monitor.start { connectivity in
+            connectivityUpdateReceived.fulfill()
+            XCTAssertNotNil(connectivity)
+        }
+        wait(for: [connectivityUpdateReceived], timeout: 1)
+        monitor.cancel()
+    }
+
+    func testMockConnectivityMonitor() {
+        let mockMonitor = MockConnectivityMonitor()
+        let monitor = ConnectivityMonitor(monitor: mockMonitor)
+        let connectivityUpdateReceived = expectation(description: "connectivity update received")
+        connectivityUpdateReceived.expectedFulfillmentCount = 3
+        monitor.start { updates in
+            XCTAssertNotNil(updates)
+            connectivityUpdateReceived.fulfill()
+        }
+        mockMonitor.sendConnectivityUpdate(.init())
+        mockMonitor.sendConnectivityUpdate(.init())
+        mockMonitor.sendConnectivityUpdate(.init())
+        wait(for: [connectivityUpdateReceived], timeout: 1)
+        monitor.cancel()
+    }
+}

--- a/AppSyncRealTimeClientTests/Mocks/MockConnectivityMonitor.swift
+++ b/AppSyncRealTimeClientTests/Mocks/MockConnectivityMonitor.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/Mocks/MockConnectivityMonitor.swift
+++ b/AppSyncRealTimeClientTests/Mocks/MockConnectivityMonitor.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2018-2021 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+@testable import AppSyncRealTimeClient
+
+class MockConnectivityMonitor: AnyConnectivityMonitor {
+
+    private var connectivityUpdatesQueue: DispatchQueue?
+    private var onConnectivityUpdates: ConnectivityUpdates?
+
+    func start(
+        connectivityUpdatesQueue: DispatchQueue,
+        onConnectivityUpdates: @escaping ConnectivityUpdates
+    ) {
+        self.connectivityUpdatesQueue = connectivityUpdatesQueue
+        self.onConnectivityUpdates = onConnectivityUpdates
+    }
+
+    func sendConnectivityUpdate(_ connectivityPath: ConnectivityPath) {
+        guard let onConnectivityUpdates = onConnectivityUpdates,
+              let connectivityUpdatesQueue = connectivityUpdatesQueue else {
+            return
+        }
+        connectivityUpdatesQueue.async {
+            onConnectivityUpdates(connectivityPath)
+        }
+    }
+
+    func cancel() {
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
When there is an intermittent network issue while the websocket is connected, the subscriptions will stop receiving events and take around 5 minutes to reconnect once the stale connection timeout occurs. During these 5 minutes, the network may have gone back online leaving a window of silence despite mutations being sent successfully. This PR adds a connectivity monitor to listen to network changes. When the network goes down while connected, it will mark it as a stale connection, and when it goes back up, it will attempt to reconnect.

*Description of changes:*
- Add ConnectivityMonitor (structure copied from @brennanMKE's [ConnectivityKit](https://github.com/brennanMKE/ConnectivityKit) that uses [NWPathMonitor](https://developer.apple.com/documentation/network/nwpathmonitor). NWPathMonitor as recommended by Apple in [Introducing Network.framework](https://developer.apple.com/videos/play/wwdc2018/715) at 56mins to replace Reachability in iOS 12.
- ConnectivityMonitor is used along side the stale connection code with the following logic: If the websocket is connected and the network is offline, then mark the connection as stale. If the connection is stale and the network is online again, stop the stale timer, disconnect the websocket and send the connection error to the subscriptions. Stopping the stale timer to prevent inaccurate disconnect if fired, disconnecting the websocket is the first step to begin the reconnect w/ exponential back-off retries. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
