### PR TITLE
fix: remove weak reference on connection provider in subscription

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -10,7 +10,7 @@
   --elseposition same-line
 
 --enable fileHeader
-  --header "//\n// Copyright 2018-{created.year} Amazon.com,\n// Inc. or its affiliates. All Rights Reserved.\n//\n// SPDX-License-Identifier: Apache-2.0\n//"
+  --header "//\n// Copyright Amazon.com Inc. or its affiliates.\n// All Rights Reserved.\n//\n// SPDX-License-Identifier: Apache-2.0\n//"
 
 --disable hoistPatternLet
   --patternlet inline

--- a/AppSyncRTCSample/AppDelegate.swift
+++ b/AppSyncRTCSample/AppDelegate.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2020 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRTCSample/AppSyncRTCProvider.swift
+++ b/AppSyncRTCSample/AppSyncRTCProvider.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2020 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRTCSample/ContentView.swift
+++ b/AppSyncRTCSample/ContentView.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2020 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRTCSample/SceneDelegate.swift
+++ b/AppSyncRTCSample/SceneDelegate.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2020 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+Connection.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+Connection.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+DataHandler.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+DataHandler.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+ErrorHandler.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+ErrorHandler.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
@@ -17,7 +17,7 @@ enum SubscriptionState {
 
 public class AppSyncSubscriptionConnection: SubscriptionConnection, RetryableConnection {
     /// Connection provider that connects with the service
-    weak var connectionProvider: ConnectionProvider?
+    var connectionProvider: ConnectionProvider?
 
     /// The current state of subscription
     var subscriptionState: SubscriptionState = .notSubscribed

--- a/AppSyncRealTimeClient/Connection/RetryableConnection.swift
+++ b/AppSyncRealTimeClient/Connection/RetryableConnection.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Connection/SubscriptionConnection.swift
+++ b/AppSyncRealTimeClient/Connection/SubscriptionConnection.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Connection/SubscriptionItem.swift
+++ b/AppSyncRealTimeClient/Connection/SubscriptionItem.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/AppSyncConnectionRequest.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppSyncConnectionRequest.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/AppSyncMessage+Encodable.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppSyncMessage+Encodable.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/AppSyncMessage.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppSyncMessage.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/AppSyncResponse.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppSyncResponse.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+ConnectionInterceptable.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+ConnectionInterceptable.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+MessageInterceptable.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+MessageInterceptable.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProviderResponse.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProviderResponse.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/ConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/ConnectionProvider.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/ConnectionProviderError.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/ConnectionProviderError.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/ConnectionProviderFactory.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/ConnectionProviderFactory.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/ConnectionProvider/InterceptableConnection.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/InterceptableConnection.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Interceptor/APIKeyAuthInterceptor.swift
+++ b/AppSyncRealTimeClient/Interceptor/APIKeyAuthInterceptor.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Interceptor/OIDCAuthInterceptor.swift
+++ b/AppSyncRealTimeClient/Interceptor/OIDCAuthInterceptor.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Interceptor/RealtimeGatewayURLInterceptor.swift
+++ b/AppSyncRealTimeClient/Interceptor/RealtimeGatewayURLInterceptor.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Support/AppSyncJSONHelper.swift
+++ b/AppSyncRealTimeClient/Support/AppSyncJSONHelper.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Support/AppSyncJSONValue.swift
+++ b/AppSyncRealTimeClient/Support/AppSyncJSONValue.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Support/AppSyncLogger.swift
+++ b/AppSyncRealTimeClient/Support/AppSyncLogger.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Support/AppSyncURLHelper.swift
+++ b/AppSyncRealTimeClient/Support/AppSyncURLHelper.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Support/AtomicValue.swift
+++ b/AppSyncRealTimeClient/Support/AtomicValue.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Support/CountdownTimer.swift
+++ b/AppSyncRealTimeClient/Support/CountdownTimer.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Support/OIDCAuthProvider.swift
+++ b/AppSyncRealTimeClient/Support/OIDCAuthProvider.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Support/SubscriptionConnectionType.swift
+++ b/AppSyncRealTimeClient/Support/SubscriptionConnectionType.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Support/SubscriptionConstants.swift
+++ b/AppSyncRealTimeClient/Support/SubscriptionConstants.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Websocket/AppSyncWebsocketProvider.swift
+++ b/AppSyncRealTimeClient/Websocket/AppSyncWebsocketProvider.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter+Delegate.swift
+++ b/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter+Delegate.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
+++ b/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientIntegrationTests.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientIntegrationTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientTestBase.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientTestBase.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientIntegrationTests/StarscreamAdapterTests.swift
+++ b/AppSyncRealTimeClientIntegrationTests/StarscreamAdapterTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientIntegrationTests/Support/ConfigurationHelper.swift
+++ b/AppSyncRealTimeClientIntegrationTests/Support/ConfigurationHelper.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientIntegrationTests/Support/Error+Extension.swift
+++ b/AppSyncRealTimeClientIntegrationTests/Support/Error+Extension.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientIntegrationTests/Support/TestCommonConstants.swift
+++ b/AppSyncRealTimeClientIntegrationTests/Support/TestCommonConstants.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/Connection/AppSyncSubscriptionConnectionTests.swift
+++ b/AppSyncRealTimeClientTests/Connection/AppSyncSubscriptionConnectionTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderStaleConnectionTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderStaleConnectionTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/ConnectionProvider/RealtimeConnectionProviderTestBase.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/RealtimeConnectionProviderTestBase.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/Interceptor/APIKeyAuthInterceptorTests.swift
+++ b/AppSyncRealTimeClientTests/Interceptor/APIKeyAuthInterceptorTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/Interceptor/AppSyncJSONHelperTests.swift
+++ b/AppSyncRealTimeClientTests/Interceptor/AppSyncJSONHelperTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/Interceptor/AppSyncURLHelperTests.swift
+++ b/AppSyncRealTimeClientTests/Interceptor/AppSyncURLHelperTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/Interceptor/OIDCAuthInterceptorTests.swift
+++ b/AppSyncRealTimeClientTests/Interceptor/OIDCAuthInterceptorTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/Mocks/MockConnectionProvider.swift
+++ b/AppSyncRealTimeClientTests/Mocks/MockConnectionProvider.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/Mocks/MockWebsocketProvider.swift
+++ b/AppSyncRealTimeClientTests/Mocks/MockWebsocketProvider.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/Support/CountdownTimerTests.swift
+++ b/AppSyncRealTimeClientTests/Support/CountdownTimerTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/Support/RealtimeGatewayURLInterceptorTests.swift
+++ b/AppSyncRealTimeClientTests/Support/RealtimeGatewayURLInterceptorTests.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/AppSyncRealTimeClientTests/TestSupport/Error+Extension.swift
+++ b/AppSyncRealTimeClientTests/TestSupport/Error+Extension.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2021 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/HostApp/AppDelegate.swift
+++ b/HostApp/AppDelegate.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2020 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/HostApp/ContentView.swift
+++ b/HostApp/ContentView.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2020 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/HostApp/SceneDelegate.swift
+++ b/HostApp/SceneDelegate.swift
@@ -1,6 +1,6 @@
 //
-// Copyright 2018-2020 Amazon.com,
-// Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Is there a retain cycle if we remove the weak reference? 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
