### PR TITLE
fix: data race in CountdownTimer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ credentials-mc.json
 amplify
 build/
 .build/
+.vscode/
 dist/
 node_modules/
 aws-exports.js

--- a/AppSyncRealTimeClient.xcodeproj/xcshareddata/xcschemes/AppSyncRealTimeClient.xcscheme
+++ b/AppSyncRealTimeClient.xcodeproj/xcshareddata/xcschemes/AppSyncRealTimeClient.xcscheme
@@ -45,7 +45,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AppSyncRealTimeClient.xcodeproj/xcshareddata/xcschemes/AppSyncRealTimeClient.xcscheme
+++ b/AppSyncRealTimeClient.xcodeproj/xcshareddata/xcschemes/AppSyncRealTimeClient.xcscheme
@@ -45,6 +45,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
@@ -7,30 +7,27 @@
 
 import Foundation
 
+/// Consolidates usage and parameters passed to the `staleConnectionTimer` methods.
 extension RealtimeConnectionProvider {
 
     /// Start a stale connection timer, first invalidating and destroying any existing timer
     func startStaleConnectionTimer() {
-        AppSyncLogger.debug("[RealtimeConnectionProvider] Starting stale connection timer for \(staleConnectionTimeout.get())s")
-        if staleConnectionTimer != nil {
-            stopStaleConnectionTimer()
-        }
-        staleConnectionTimer = CountdownTimer(interval: staleConnectionTimeout.get()) {
+        AppSyncLogger.debug("[RealtimeConnectionProvider] Starting stale connection timer for \(staleConnectionTimer.interval)s")
+
+        staleConnectionTimer.start(interval: RealtimeConnectionProvider.staleConnectionTimeout) {
             self.disconnectStaleConnection()
         }
     }
 
-    /// Stop and destroy any existing stale connection timer
-    func stopStaleConnectionTimer() {
-        AppSyncLogger.debug("[RealtimeConnectionProvider] Stopping and destroying stale connection timer")
-        staleConnectionTimer?.invalidate()
-        staleConnectionTimer = nil
+    /// Reset the stale connection timer in response to receiving a message from the websocket
+    func resetStaleConnectionTimer(interval: TimeInterval? = nil) {
+        AppSyncLogger.debug("[RealtimeConnectionProvider] Resetting stale connection timer")
+        staleConnectionTimer.reset(interval: interval)
     }
 
-    /// Reset the stale connection timer in response to receiving a message
-    func resetStaleConnectionTimer() {
-        AppSyncLogger.debug("[RealtimeConnectionProvider] Resetting stale connection timer")
-        staleConnectionTimer?.resetCountdown()
+    /// Stops the timer when disconnecting the websocket.
+    func invalidateStaleConnectionTimer() {
+        staleConnectionTimer.invalidate()
     }
 
     /// Fired when the stale connection timer expires

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
@@ -87,7 +87,7 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
 
         let interval = value / 1_000
 
-        guard interval != staleConnectionTimer?.interval else {
+        guard interval != staleConnectionTimer.interval else {
             return
         }
 
@@ -97,8 +97,7 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
             instructions: \(interval)s
             """
         )
-        staleConnectionTimeout.set(interval)
-        startStaleConnectionTimer()
+        resetStaleConnectionTimer(interval: interval)
     }
 
     /// Resolves & dispatches errors from `response`.

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -10,6 +10,10 @@ import Foundation
 /// Appsync Real time connection that connects to subscriptions
 /// through websocket.
 public class RealtimeConnectionProvider: ConnectionProvider {
+    /// Maximum number of seconds a connection may go without receiving a keep alive
+    /// message before we consider it stale and force a disconnect
+    static let staleConnectionTimeout: TimeInterval = 5 * 60
+
     private let url: URL
     var listeners: [String: ConnectionProviderCallback]
 
@@ -19,14 +23,10 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     var messageInterceptors: [MessageInterceptor]
     var connectionInterceptors: [ConnectionInterceptor]
 
-    /// Maximum number of seconds a connection may go without receiving a keep alive
-    /// message before we consider it stale and force a disconnect
-    let staleConnectionTimeout: AtomicValue<TimeInterval>
-
     /// A timer that automatically disconnects the current connection if it goes longer
     /// than `staleConnectionTimeout` without activity. Receiving any data or "keep
     /// alive" message will cause the timer to be reset to the full interval.
-    var staleConnectionTimer: CountdownTimer?
+    var staleConnectionTimer: CountdownTimer
 
     /// Manages concurrency for socket connections, disconnections, writes, and status reports.
     ///
@@ -47,7 +47,7 @@ public class RealtimeConnectionProvider: ConnectionProvider {
         self.status = .notConnected
         self.messageInterceptors = []
         self.connectionInterceptors = []
-        self.staleConnectionTimeout = AtomicValue(initialValue: 5 * 60)
+        self.staleConnectionTimer = CountdownTimer()
         self.connectionQueue = DispatchQueue(
             label: "com.amazonaws.AppSyncRealTimeConnectionProvider.serialQueue"
         )
@@ -111,8 +111,7 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     public func disconnect() {
         connectionQueue.async {
             self.websocket.disconnect()
-            self.staleConnectionTimer?.invalidate()
-            self.staleConnectionTimer = nil
+            self.invalidateStaleConnectionTimer()
         }
     }
 
@@ -134,8 +133,7 @@ public class RealtimeConnectionProvider: ConnectionProvider {
                 AppSyncLogger.debug("[RealtimeConnectionProvider] all subscriptions removed, disconnecting websocket connection.")
                 self.status = .notConnected
                 self.websocket.disconnect()
-                self.staleConnectionTimer?.invalidate()
-                self.staleConnectionTimer = nil
+                self.invalidateStaleConnectionTimer()
             }
         }
     }

--- a/AppSyncRealTimeClient/Support/CountdownTimer.swift
+++ b/AppSyncRealTimeClient/Support/CountdownTimer.swift
@@ -14,31 +14,54 @@ import Foundation
 /// includes work that must be performed on a specific queue, make sure to dispatch
 /// it inside the closure.
 class CountdownTimer {
-    /// The interval after which the timer will fire
-    let interval: TimeInterval
+    private static let defaultInterval: TimeInterval = 5 * 60
 
+    /// The interval in seconds of the timer
+    private var _interval: TimeInterval?
     private let lock: NSLock
     private var workItem: DispatchWorkItem?
-    private let onCountdownComplete: () -> Void
+    private var onCountdownComplete: (() -> Void)?
 
-    init(interval: TimeInterval, onCountdownComplete: @escaping () -> Void) {
+    init() {
         self.lock = NSLock()
-        self.interval = interval
-        self.onCountdownComplete = onCountdownComplete
-        createAndScheduleTimer()
     }
 
-    /// Resets the countdown of the timer to `interval`
-    func resetCountdown() {
+    var interval: TimeInterval {
+        _interval ?? CountdownTimer.defaultInterval
+    }
+
+    /// Starts the countdown of the timer with `interval` and perform
+    ///
+    /// - Parameters:
+    ///   - interval: The interval after which the timer will fire, and be reset on.
+    ///   - onCountdownComplete: The closure to perform when the timer fires.
+    func start(interval: TimeInterval, onCountdownComplete: @escaping () -> Void) {
         lock.lock()
         defer {
             lock.unlock()
         }
+        _interval = interval
+        self.onCountdownComplete = onCountdownComplete
         cancelAndClearWorkItem()
-        createAndScheduleTimer()
+        createAndScheduleTimer(interval: interval)
     }
 
-    /// Invalidates the timer
+    /// Resets the timer to begin counting down from the `interval` again.
+    ///
+    /// - Parameter interval: Optionally pass in a new interval for the timer.
+    func reset(interval: TimeInterval? = nil) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        if let interval = interval {
+            _interval = interval
+        }
+        cancelAndClearWorkItem()
+        createAndScheduleTimer(interval: self.interval)
+    }
+
+    /// Invalidates/stops the timer
     func invalidate() {
         lock.lock()
         defer {
@@ -47,9 +70,16 @@ class CountdownTimer {
         cancelAndClearWorkItem()
     }
 
+    // MARK: - Private helpers
+
+    /// Invoked  by all puclic methods (`start`, `reset`, `invalidate`) to clear the previous timer
     private func cancelAndClearWorkItem() {
-        workItem?.cancel()
-        workItem = nil
+        guard let workItem = workItem else {
+            return
+        }
+
+        workItem.cancel()
+        self.workItem = nil
     }
 
     /// Invoked by the timer. Do not execute this method directly.
@@ -64,13 +94,13 @@ class CountdownTimer {
             return
         }
 
-        onCountdownComplete()
+        onCountdownComplete?()
     }
 
-    private func createAndScheduleTimer() {
+    /// Invoked by `start` and `reset` when creating a new timer.
+    private func createAndScheduleTimer(interval: TimeInterval) {
         let workItem = DispatchWorkItem { self.timerFired() }
         self.workItem = workItem
         DispatchQueue.global().asyncAfter(deadline: .now() + interval, execute: workItem)
     }
-
 }

--- a/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderStaleConnectionTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderStaleConnectionTests.swift
@@ -57,7 +57,7 @@ class ConnectionProviderStaleConnectionTests: RealtimeConnectionProviderTestBase
         let provider = createProviderAndConnect()
 
         wait(for: [receivedConnected], timeout: 0.05)
-        XCTAssertEqual(provider.staleConnectionTimeout.get(), expectedTimeoutInSeconds)
+        XCTAssertEqual(provider.staleConnectionTimer.interval, expectedTimeoutInSeconds)
 
         waitForExpectations(timeout: 0.05)
     }

--- a/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderTests.swift
@@ -220,7 +220,7 @@ class ConnectionProviderTests: RealtimeConnectionProviderTestBase {
         let provider = createProviderAndConnect()
 
         wait(for: [receivedConnected], timeout: 0.05)
-        XCTAssertEqual(provider.staleConnectionTimeout.get(), expectedTimeoutInSeconds)
+        XCTAssertEqual(provider.staleConnectionTimer.interval, expectedTimeoutInSeconds)
 
         waitForExpectations(timeout: 0.05)
     }

--- a/AppSyncRealTimeClientTests/Support/CountdownTimerTests.swift
+++ b/AppSyncRealTimeClientTests/Support/CountdownTimerTests.swift
@@ -19,7 +19,8 @@ class CountdownTimerTests: XCTestCase {
 
     func testTimerFires() {
         let timerFired = expectation(description: "timerFired")
-        let timer = CountdownTimer(interval: 0.1) { timerFired.fulfill() }
+        let timer = CountdownTimer()
+        timer.start(interval: 0.1) { timerFired.fulfill() }
         waitForExpectations(timeout: 1.0)
         timer.invalidate()
     }
@@ -27,7 +28,8 @@ class CountdownTimerTests: XCTestCase {
     func testTimerDoesNotFireEarly() {
         let timerFired = expectation(description: "timerFired")
         timerFired.isInverted = true
-        let timer = CountdownTimer(interval: 0.5) { timerFired.fulfill() }
+        let timer = CountdownTimer()
+        timer.start(interval: 0.5) { timerFired.fulfill() }
         waitForExpectations(timeout: 0.1)
         timer.invalidate()
     }
@@ -36,7 +38,8 @@ class CountdownTimerTests: XCTestCase {
         let timerFired = expectation(description: "timerFired")
         timerFired.isInverted = true
         XCTAssert(Thread.isMainThread)
-        let timer = CountdownTimer(interval: 1.0) {
+        let timer = CountdownTimer()
+        timer.start(interval: 1.0) {
             timerFired.fulfill()
             XCTAssertFalse(Thread.isMainThread)
         }
@@ -47,7 +50,10 @@ class CountdownTimerTests: XCTestCase {
     func testTimerDoesNotFireAfterInvalidate() {
         let timerFired = expectation(description: "timerFired")
         timerFired.isInverted = true
-        let timer = CountdownTimer(interval: 0.1) { timerFired.fulfill() }
+        let timer = CountdownTimer()
+        timer.start(interval: 0.1) {
+            timerFired.fulfill()
+        }
         timer.invalidate()
         waitForExpectations(timeout: 0.2)
     }
@@ -66,13 +72,13 @@ class CountdownTimerTests: XCTestCase {
     /// - 100: Ensure timer has not yet fired
     /// - 300: Ensure timer has fired
     func testTimerFiresOnSchedule() {
-        var timer: CountdownTimer!
+        let timer = CountdownTimer()
         let timerHasFired = AtomicValue(initialValue: false)
 
         let timerShouldHaveFired = expectation(description: "the timer should have fired by now")
 
         DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(0)) {
-            timer = CountdownTimer(interval: 0.200) {
+            timer.start(interval: 0.200) {
                 timerHasFired.set(true)
             }
         }
@@ -103,17 +109,20 @@ class CountdownTimerTests: XCTestCase {
     /// Test timing in ms:
     /// - 000: Set up a timer with a .3 sec interval
     /// - 100: Ensure timer has not yet fired
-    /// - 200: Issue a `resetCountdown`
+    /// - 200: Issue a `reset` before timer would fire
     /// - 400: Ensure timer has not yet fired
-    /// - 600: Ensure timer has yet fired
+    /// - 600: Timer should fire around this time
+    /// - 700: Ensure timer has fired
     func testTimerResets() {
-        var timer: CountdownTimer!
+        let timer = CountdownTimer()
         let timerHasFired = AtomicValue(initialValue: false)
 
         let timerShouldHaveFired = expectation(description: "the timer should have fired by now")
 
         DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(0)) {
-            timer = CountdownTimer(interval: 0.300) { timerHasFired.set(true) }
+            timer.start(interval: 0.300) {
+                timerHasFired.set(true)
+            }
         }
 
         DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(100)) {
@@ -121,14 +130,14 @@ class CountdownTimerTests: XCTestCase {
         }
 
         DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(200)) {
-            timer.resetCountdown()
+            timer.reset()
         }
 
         DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(400)) {
             XCTAssertFalse(timerHasFired.get(), "The timer should not have fired yet")
         }
 
-        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(600)) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(700)) {
             XCTAssert(timerHasFired.get(), "The timer should have fired by now")
             timerShouldHaveFired.fulfill()
         }
@@ -140,12 +149,21 @@ class CountdownTimerTests: XCTestCase {
 
     /// Test that concurrent operations on the timer do not result in data races
     func testConcurrency() {
-        let timerShouldHaveFired = expectation(description: "the timer should have fired by now")
-        let timer = CountdownTimer(interval: 0.1) { timerShouldHaveFired.fulfill() }
-        DispatchQueue.concurrentPerform(iterations: 10_000) { _ in
-            timer.resetCountdown()
-        }
-        waitForExpectations(timeout: 1.0)
-    }
+        let concurrentCount = expectation(description: "timer fired at least once")
+        concurrentCount.expectedFulfillmentCount = 10_000
+        let timer = CountdownTimer()
 
+        DispatchQueue.concurrentPerform(iterations: 10_000) { _ in
+            let randomInt = Int.random(in: 1 ... 3)
+            if randomInt == 1 {
+                timer.start(interval: 0.01) { }
+            } else if randomInt == 2 {
+                timer.invalidate()
+            } else {
+                timer.reset()
+            }
+            concurrentCount.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The data race occurred when the countdown timer was first created and at the same time it was invalidated. The underlying `workItem: DispatchWorkItem` was being set and canceled at the same time. The scenario is

1. Connecting to the websocket
2. When connected, send the connect init message and start the timer
3. When receiving the connection ack message from the websocket (or any other messages for that matter at `handleResponse(_ response)`), then reset the timer. The timer is reset on every message to ensure the freshness of the connection. Whenever there's a keep-alive or any message, the stale connection timer is reset. If 5 minutes elapsed and the timer fires, it disconnects the websocket and signals the subscriptions to attempt the retry reconnect logic.

Although, when run against a real websocket endpoint, it will take some time to receive the message so resetting the timer would be much later so this probably would not occur in production. In the unit test with thread sanitizer enabled, the websocket is mocked to return the response immediately on connect init message, hitting the data race.

In cleaning up this code, 
- CountdownTimer is now an instance that can be reused across multiple websocket connects, no need to deference and create a new instance. To support this, every method called on the timer will first cancel and clear the existing workItem.
- The staleConnectionTimer was also being invalidated and new instance was created if AppSync returns a different interval. Now it handles this by calling `reset` with the new interval. (BTW, this never happens because AppSync always returns 5 mins, which is the same as the client hardcoded interval). 
- Creating a new instance does not start the timer. The timer is started through `start(interval:onComplete)` which is under the `NSLock`, thus all public methods are thread safe.


Data race 
```
WARNING: ThreadSanitizer: data race (pid=15374)
  Read of size 8 at 0x0001080478a0 by thread T3 (mutexes: write M1119):
    #0 CountdownTimer.cancelAndClearWorkItem() CountdownTimer.swift:51 (AppSyncRealTimeClient:arm64+0x25690)
    #1 CountdownTimer.resetCountdown() CountdownTimer.swift:37 (AppSyncRealTimeClient:arm64+0x25418)
    #2 RealtimeConnectionProvider.resetStaleConnectionTimer() RealtimeConnectionProvider+StaleConnection.swift:33 (AppSyncRealTimeClient:arm64+0x110ec)
    #3 RealtimeConnectionProvider.handleResponse(_:) RealtimeConnectionProvider+Websocket.swift:47 (AppSyncRealTimeClient:arm64+0x3495c)
    #4 RealtimeConnectionProvider.websocketDidReceiveData(provider:data:) RealtimeConnectionProvider+Websocket.swift:37 (AppSyncRealTimeClient:arm64+0x345f0)
    #5 protocol witness for AppSyncWebsocketDelegate.websocketDidReceiveData(provider:data:) in conformance RealtimeConnectionProvider <compiler-generated> (AppSyncRealTimeClient:arm64+0x3647c)
    #6 closure #3 in ConnectionProviderStaleConnectionTests.testServiceOverridesStaleConnectionTimeout() ConnectionProviderStaleConnectionTests.swift:45 (AppSyncRealTimeClientTests:arm64+0x29d70)
    #7 partial apply for closure #3 in ConnectionProviderStaleConnectionTests.testServiceOverridesStaleConnectionTimeout() <compiler-generated> (AppSyncRealTimeClientTests:arm64+0x29e90)
    #8 MockWebsocketProvider.write(message:) MockWebsocketProvider.swift:42 (AppSyncRealTimeClientTests:arm64+0xd6fc)
    #9 protocol witness for AppSyncWebsocketProvider.write(message:) in conformance MockWebsocketProvider <compiler-generated> (AppSyncRealTimeClientTests:arm64+0xd948)
    #10 closure #1 in RealtimeConnectionProvider.write(_:) RealtimeConnectionProvider.swift:97 (AppSyncRealTimeClient:arm64+0x14fe0)
    #11 partial apply for closure #1 in RealtimeConnectionProvider.write(_:) <compiler-generated> (AppSyncRealTimeClient:arm64+0x15264)
    #12 thunk for @escaping @callee_guaranteed () -> () <compiler-generated> (AppSyncRealTimeClient:arm64+0x11484)
    #13 __tsan::invoke_and_release_block(void*) <null>:84947348 (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x704bc)
    #14 _dispatch_client_callout <null>:84947348 (libdispatch.dylib:arm64+0x35a0)

  Previous write of size 8 at 0x0001080478a0 by thread T4:
    #0 CountdownTimer.createAndScheduleTimer() CountdownTimer.swift:72 (AppSyncRealTimeClient:arm64+0x25c88)
    #1 CountdownTimer.init(interval:onCountdownComplete:) CountdownTimer.swift:28 (AppSyncRealTimeClient:arm64+0x2536c)
    #2 CountdownTimer.__allocating_init(interval:onCountdownComplete:) CountdownTimer.swift (AppSyncRealTimeClient:arm64+0x2523c)
    #3 RealtimeConnectionProvider.startStaleConnectionTimer() RealtimeConnectionProvider+StaleConnection.swift:18 (AppSyncRealTimeClient:arm64+0x10b08)
    #4 RealtimeConnectionProvider.websocketDidConnect(provider:) RealtimeConnectionProvider+Websocket.swift:17 (AppSyncRealTimeClient:arm64+0x33d60)
    #5 protocol witness for AppSyncWebsocketDelegate.websocketDidConnect(provider:) in conformance RealtimeConnectionProvider <compiler-generated> (AppSyncRealTimeClient:arm64+0x363d4)
    #6 closure #1 in closure #1 in ConnectionProviderStaleConnectionTests.testServiceOverridesStaleConnectionTimeout() ConnectionProviderStaleConnectionTests.swift:31 (AppSyncRealTimeClientTests:arm64+0x29a04)
    #7 partial apply for closure #1 in closure #1 in ConnectionProviderStaleConnectionTests.testServiceOverridesStaleConnectionTimeout() <compiler-generated> (AppSyncRealTimeClientTests:arm64+0x2a8f0)
    #8 thunk for @escaping @callee_guaranteed () -> () <compiler-generated> (AppSyncRealTimeClientTests:arm64+0x572c)
    #9 __tsan::invoke_and_release_block(void*) <null>:84947348 (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x704bc)
    #10 _dispatch_client_callout <null>:84947348 (libdispatch.dylib:arm64+0x35a0)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
