### PR TITLE
fix: Throttle AppSync LimitExceeded errors

### DIFF
--- a/AppSyncRealTimeClient.xcodeproj/project.pbxproj
+++ b/AppSyncRealTimeClient.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2143D4B227BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2143D4B127BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift */; };
 		2164E65D2639AD5600385027 /* StarscreamAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164E65C2639AD5600385027 /* StarscreamAdapterTests.swift */; };
 		2164E674263C58CE00385027 /* AppSyncRealTimeClientTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164E673263C58CD00385027 /* AppSyncRealTimeClientTestBase.swift */; };
+		217C74D227C45B6600AE054F /* AppSyncSubscriptionConnectionErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217C74D127C45B6600AE054F /* AppSyncSubscriptionConnectionErrorHandlerTests.swift */; };
 		217F39992405D9D500F1A0B3 /* AppSyncRealTimeClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 217F398F2405D9D500F1A0B3 /* AppSyncRealTimeClient.framework */; };
 		217F39CC2406E98400F1A0B3 /* AppSyncResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217F39AA2406E98300F1A0B3 /* AppSyncResponse.swift */; };
 		217F39CD2406E98400F1A0B3 /* InterceptableConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217F39AB2406E98300F1A0B3 /* InterceptableConnection.swift */; };
@@ -134,6 +135,7 @@
 		2143D4B127BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientFailureTests.swift; sourceTree = "<group>"; };
 		2164E65C2639AD5600385027 /* StarscreamAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarscreamAdapterTests.swift; sourceTree = "<group>"; };
 		2164E673263C58CD00385027 /* AppSyncRealTimeClientTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientTestBase.swift; sourceTree = "<group>"; };
+		217C74D127C45B6600AE054F /* AppSyncSubscriptionConnectionErrorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncSubscriptionConnectionErrorHandlerTests.swift; sourceTree = "<group>"; };
 		217F398F2405D9D500F1A0B3 /* AppSyncRealTimeClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AppSyncRealTimeClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		217F39932405D9D500F1A0B3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		217F39982405D9D500F1A0B3 /* AppSyncRealTimeClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppSyncRealTimeClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -431,6 +433,7 @@
 		217F39E82406EA3F00F1A0B3 /* Connection */ = {
 			isa = PBXGroup;
 			children = (
+				217C74D127C45B6600AE054F /* AppSyncSubscriptionConnectionErrorHandlerTests.swift */,
 				217F39E92406EA3F00F1A0B3 /* AppSyncSubscriptionConnectionTests.swift */,
 			);
 			path = Connection;
@@ -1199,6 +1202,7 @@
 				21D38B8C240A39E400EC2A8D /* APIKeyAuthInterceptorTests.swift in Sources */,
 				21D38B8B240A39E400EC2A8D /* AppSyncJSONHelperTests.swift in Sources */,
 				217F39F32406EA4000F1A0B3 /* RealtimeGatewayURLInterceptorTests.swift in Sources */,
+				217C74D227C45B6600AE054F /* AppSyncSubscriptionConnectionErrorHandlerTests.swift in Sources */,
 				FA67507E24D33976005A1345 /* RealtimeConnectionProviderTestBase.swift in Sources */,
 				219BFF6A27A9AC6E000FC148 /* ConnectivityMonitorTests.swift in Sources */,
 				978409BA2739C7E1002362A7 /* AppSyncURLHelperTests.swift in Sources */,

--- a/AppSyncRealTimeClient.xcodeproj/project.pbxproj
+++ b/AppSyncRealTimeClient.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2143D46727B5D9B40066B2F7 /* RealTimeConnectionProviderResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2143D46627B5D9B40066B2F7 /* RealTimeConnectionProviderResponseTests.swift */; };
 		2143D4B027BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2143D4AF27BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift */; };
 		2143D4B227BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2143D4B127BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift */; };
+		2151D5CA27C68C3C00F3C866 /* ConnectionProviderHandleErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2151D5C927C68C3C00F3C866 /* ConnectionProviderHandleErrorTests.swift */; };
 		2164E65D2639AD5600385027 /* StarscreamAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164E65C2639AD5600385027 /* StarscreamAdapterTests.swift */; };
 		2164E674263C58CE00385027 /* AppSyncRealTimeClientTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164E673263C58CD00385027 /* AppSyncRealTimeClientTestBase.swift */; };
 		217C74D227C45B6600AE054F /* AppSyncSubscriptionConnectionErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217C74D127C45B6600AE054F /* AppSyncSubscriptionConnectionErrorHandlerTests.swift */; };
@@ -133,6 +134,7 @@
 		2143D46627B5D9B40066B2F7 /* RealTimeConnectionProviderResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealTimeConnectionProviderResponseTests.swift; sourceTree = "<group>"; };
 		2143D4AF27BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncRealTimeClient.swift; sourceTree = "<group>"; };
 		2143D4B127BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientFailureTests.swift; sourceTree = "<group>"; };
+		2151D5C927C68C3C00F3C866 /* ConnectionProviderHandleErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionProviderHandleErrorTests.swift; sourceTree = "<group>"; };
 		2164E65C2639AD5600385027 /* StarscreamAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarscreamAdapterTests.swift; sourceTree = "<group>"; };
 		2164E673263C58CD00385027 /* AppSyncRealTimeClientTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientTestBase.swift; sourceTree = "<group>"; };
 		217C74D127C45B6600AE054F /* AppSyncSubscriptionConnectionErrorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncSubscriptionConnectionErrorHandlerTests.swift; sourceTree = "<group>"; };
@@ -453,6 +455,7 @@
 			isa = PBXGroup;
 			children = (
 				2143D46527B5D9730066B2F7 /* AppSyncRealTimeConnection */,
+				2151D5C927C68C3C00F3C866 /* ConnectionProviderHandleErrorTests.swift */,
 				FA67507F24D339B0005A1345 /* ConnectionProviderStaleConnectionTests.swift */,
 				217F39ED2406EA4000F1A0B3 /* ConnectionProviderTests.swift */,
 				FA67507C24D338FA005A1345 /* RealtimeConnectionProviderTestBase.swift */,
@@ -1205,6 +1208,7 @@
 				217C74D227C45B6600AE054F /* AppSyncSubscriptionConnectionErrorHandlerTests.swift in Sources */,
 				FA67507E24D33976005A1345 /* RealtimeConnectionProviderTestBase.swift in Sources */,
 				219BFF6A27A9AC6E000FC148 /* ConnectivityMonitorTests.swift in Sources */,
+				2151D5CA27C68C3C00F3C866 /* ConnectionProviderHandleErrorTests.swift in Sources */,
 				978409BA2739C7E1002362A7 /* AppSyncURLHelperTests.swift in Sources */,
 				FA67508424D33ACC005A1345 /* CountdownTimerTests.swift in Sources */,
 				FA67508024D339B0005A1345 /* ConnectionProviderStaleConnectionTests.swift in Sources */,

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
@@ -103,7 +103,7 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
     /// Resolves & dispatches errors from `response`.
     ///
     /// - Warning: This method must be invoked on the `connectionQueue`
-    private func handleError(response: RealtimeConnectionProviderResponse) {
+    func handleError(response: RealtimeConnectionProviderResponse) {
         // If we get an error in connection inprogress state, return back as connection error.
         guard status != .inProgress else {
             status = .notConnected

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
@@ -111,19 +111,38 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
             return
         }
 
-        // Return back as generic error if there is no identifier.
+        if response.isLimitExceededError() {
+            let limitExceedError = ConnectionProviderError.limitExceeded(response.id)
+
+            guard response.id == nil else {
+                updateCallback(event: .error(limitExceedError))
+                return
+            }
+
+            if #available(iOS 13.0, *) {
+                self.limitExceededSubject.send(limitExceedError)
+                return
+            } else {
+                updateCallback(event: .error(limitExceedError))
+                return
+            }
+        }
+
+        if response.isMaxSubscriptionReachedError() {
+            let limitExceedError = ConnectionProviderError.limitExceeded(response.id)
+            updateCallback(event: .error(limitExceedError))
+            return
+        }
+
+        // If the type of error is not handled (by checking `isLimitExceededError`, `isMaxSubscriptionReachedError`,
+        // etc), and is not for a specific subscription, then return a generic error
         guard let identifier = response.id else {
             let genericError = ConnectionProviderError.other
             updateCallback(event: .error(genericError))
             return
         }
 
-        if response.isMaxSubscriptionReachedError() {
-            let limitExceedError = ConnectionProviderError.limitExceeded(identifier)
-            updateCallback(event: .error(limitExceedError))
-            return
-        }
-
+        // Default scenario - return the error with subscription id and error payload.
         let subscriptionError = ConnectionProviderError.subscription(identifier, response.payload)
         updateCallback(event: .error(subscriptionError))
     }

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 
 /// Appsync Real time connection that connects to subscriptions
 /// through websocket.
@@ -43,6 +44,20 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     /// The serial queue on which status & message callbacks from the web socket are invoked.
     private let serialCallbackQueue: DispatchQueue
 
+    /// Throttle when AppSync sends LimitExceeded error. High rate of subscriptions requests will cause AppSync to send
+    /// connection level LimitExceeded errors for each subscribe made. A connection level error means that there is no
+    /// subscription id associated with the error. When handling these errors, all subscriptions will receive a message
+    /// for the error. Use this subject to send and throttle the errors on the client side.
+    var limitExceededThrottleSink: Any?
+    var iLimitExceededSubject: Any?
+    @available(iOS 13.0, *)
+    var limitExceededSubject: PassthroughSubject<ConnectionProviderError, Never> {
+        if iLimitExceededSubject == nil {
+            iLimitExceededSubject = PassthroughSubject<ConnectionProviderError, Never>()
+        }
+        return iLimitExceededSubject as! PassthroughSubject<ConnectionProviderError, Never> // swiftlint:disable:this force_cast
+    }
+
     public convenience init(for url: URL, websocket: AppSyncWebsocketProvider) {
         self.init(url: url, websocket: websocket)
     }
@@ -60,20 +75,21 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     ) {
         self.url = url
         self.websocket = websocket
-
         self.listeners = [:]
         self.status = .notConnected
         self.messageInterceptors = []
         self.connectionInterceptors = []
-
         self.staleConnectionTimer = CountdownTimer()
         self.isStaleConnection = false
-
         self.connectionQueue = connectionQueue
         self.serialCallbackQueue = serialCallbackQueue
-
         self.connectivityMonitor = connectivityMonitor
+
         connectivityMonitor.start(onUpdates: handleConnectivityUpdates(connectivity:))
+
+        if #available(iOS 13.0, *) {
+            subscribeToLimitExceededThrottle()
+        }
     }
 
     // MARK: - ConnectionProvider methods
@@ -180,6 +196,30 @@ public class RealtimeConnectionProvider: ConnectionProvider {
             self.serialCallbackQueue.async {
                 allListeners.forEach { $0(event) }
             }
+        }
+    }
+
+    @available(iOS 13.0, *)
+    func subscribeToLimitExceededThrottle() {
+        limitExceededThrottleSink = limitExceededSubject
+            .filter {
+                // Make sure the limitExceeded error is a connection level error (no subscription id present).
+                // When id is present, it is passed back directly subscription via `updateCallback`.
+                if case .limitExceeded(let id) = $0, id == nil {
+                    return true
+                }
+                return false
+            }
+            .throttle(for: .milliseconds(150), scheduler: connectionQueue, latest: true)
+            .sink { completion in
+                switch completion {
+                case .failure(let error):
+                    AppSyncLogger.verbose("limitExceededThrottleSink failed \(error)")
+                case .finished:
+                    AppSyncLogger.verbose("limitExceededThrottleSink finished")
+                }
+        } receiveValue: { result in
+            self.updateCallback(event: .error(result))
         }
     }
 

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProviderResponse.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProviderResponse.swift
@@ -95,4 +95,25 @@ extension RealtimeConnectionProviderResponse {
         return false
     }
 
+    func isLimitExceededError() -> Bool {
+        // It is expected to contain payload with corresponding error information
+        guard let payload = payload else {
+            return false
+        }
+
+        // The observed response from the service
+        // { "type":"error",
+        //  "payload": {
+        //      "errors": {
+        //          "errorType":"LimitExceededError",
+        //          "message":"Rate limit exceeded" }}}
+        if let errors = payload["errors"],
+           case let .object(errorsObject) = errors,
+           let errorType = errorsObject["errorType"],
+           errorType == "LimitExceededError" {
+            return true
+        }
+
+        return false
+    }
 }

--- a/AppSyncRealTimeClientTests/Connection/AppSyncSubscriptionConnectionErrorHandlerTests.swift
+++ b/AppSyncRealTimeClientTests/Connection/AppSyncSubscriptionConnectionErrorHandlerTests.swift
@@ -1,0 +1,347 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import AppSyncRealTimeClient
+
+class AppSyncSubscriptionConnectionErrorHandlerTests: XCTestCase {
+
+    let connectionProvider = MockConnectionProvider()
+
+    let mockRequestString = """
+        subscription OnCreateMessage {
+            onCreateMessage {
+                __typename
+                id
+                message
+                createdAt
+            }
+        }
+        """
+
+    let variables = [String: Any]()
+
+    func testOtherSubscription() throws {
+        let connection = AppSyncSubscriptionConnection(provider: connectionProvider)
+        let connectedMessageExpectation = expectation(description: "Connected event should be fired")
+        let failedEvent = expectation(description: "Failed event should not be fired")
+        failedEvent.isInverted = true
+        let item = connection.subscribe(requestString: mockRequestString, variables: variables) { event, _ in
+            switch event {
+            case .connection(let status):
+                if status == .connected {
+                    connectedMessageExpectation.fulfill()
+                }
+            case .data:
+                XCTFail("Data event should not be published")
+            case .failed:
+                failedEvent.fulfill()
+                XCTFail("Error should not be thrown")
+            }
+        }
+        XCTAssertNotNil(item, "Subscription item should not be nil")
+        wait(for: [connectedMessageExpectation], timeout: 5)
+        XCTAssertNotNil(connectionProvider.listener)
+
+        let otherSubscriptionError = ConnectionProviderError.subscription("otherId", nil)
+        connection.handleError(error: otherSubscriptionError)
+        wait(for: [failedEvent], timeout: 5)
+    }
+
+    func testThisSubscription() throws {
+        let connection = AppSyncSubscriptionConnection(provider: connectionProvider)
+        let connectedMessageExpectation = expectation(description: "Connected event should be fired")
+        let failedEvent = expectation(description: "Failed event should be fired")
+        let item = connection.subscribe(requestString: mockRequestString, variables: variables) { event, _ in
+            switch event {
+            case .connection(let status):
+                if status == .connected {
+                    connectedMessageExpectation.fulfill()
+                }
+            case .data:
+                XCTFail("Data event should not be published")
+            case .failed(let error):
+                guard let connection = error as? ConnectionProviderError,
+                      case .subscription(let id, _) = connection,
+                      id != nil else {
+                          XCTFail("Should be .subscription(item.identifier)")
+                          return
+                }
+                failedEvent.fulfill()
+            }
+        }
+        wait(for: [connectedMessageExpectation], timeout: 5)
+        XCTAssertNotNil(connectionProvider.listener)
+
+        let thisSubscriptionError = ConnectionProviderError.subscription(item.identifier, nil)
+        connection.handleError(error: thisSubscriptionError)
+        wait(for: [failedEvent], timeout: 5)
+        XCTAssertNil(connectionProvider.listener)
+    }
+
+    func testLimitExceededOtherSubscription() throws {
+        let connection = AppSyncSubscriptionConnection(provider: connectionProvider)
+        let connectedMessageExpectation = expectation(description: "Connected event should be fired")
+        let failedEvent = expectation(description: "Failed event should not be fired")
+        failedEvent.isInverted = true
+        let item = connection.subscribe(requestString: mockRequestString, variables: variables) { event, _ in
+            switch event {
+            case .connection(let status):
+                if status == .connected {
+                    connectedMessageExpectation.fulfill()
+                }
+            case .data:
+                XCTFail("Data event should not be published")
+            case .failed:
+                failedEvent.fulfill()
+                XCTFail("Error should not be thrown")
+            }
+        }
+        XCTAssertNotNil(item, "Subscription item should not be nil")
+        wait(for: [connectedMessageExpectation], timeout: 5)
+        XCTAssertNotNil(connectionProvider.listener)
+
+        let limitExceeded = ConnectionProviderError.limitExceeded("otherId")
+        connection.handleError(error: limitExceeded)
+        wait(for: [failedEvent], timeout: 5)
+    }
+
+    func testLimitExceededThisSubscription() throws {
+        let connection = AppSyncSubscriptionConnection(provider: connectionProvider)
+        let connectedMessageExpectation = expectation(description: "Connected event should be fired")
+        let failedEvent = expectation(description: "Failed event should be fired")
+        let item = connection.subscribe(requestString: mockRequestString, variables: variables) { event, _ in
+            switch event {
+            case .connection(let status):
+                if status == .connected {
+                    connectedMessageExpectation.fulfill()
+                }
+            case .data:
+                XCTFail("Data event should not be published")
+            case .failed(let error):
+                guard let connection = error as? ConnectionProviderError,
+                      case .limitExceeded(let id) = connection, id != nil else {
+                          XCTFail("Should be .limitExceeded(item.identifier)")
+                          return
+                }
+                failedEvent.fulfill()
+            }
+        }
+        wait(for: [connectedMessageExpectation], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .subscribed)
+        XCTAssertNotNil(connectionProvider.listener)
+
+        let limitExceeded = ConnectionProviderError.limitExceeded(item.identifier)
+        connection.handleError(error: limitExceeded)
+        wait(for: [failedEvent], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .notSubscribed)
+        XCTAssertNil(connectionProvider.listener)
+    }
+
+    func testLimitExceededConnectionLevel_SubscribedShouldNoOp() throws {
+        let connection = AppSyncSubscriptionConnection(provider: connectionProvider)
+        let connectedMessageExpectation = expectation(description: "Connected event should be fired")
+        let failedEvent = expectation(description: "Failed event should not be fired")
+        failedEvent.isInverted = true
+        _ = connection.subscribe(requestString: mockRequestString, variables: variables) { event, _ in
+            switch event {
+            case .connection(let status):
+                if status == .connected {
+                    connectedMessageExpectation.fulfill()
+                }
+            case .data:
+                XCTFail("Data event should not be published")
+            case .failed:
+                failedEvent.fulfill()
+                XCTFail("Error should not be thrown")
+            }
+        }
+        wait(for: [connectedMessageExpectation], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .subscribed)
+        XCTAssertNotNil(connectionProvider.listener)
+
+        let connectionLevelLimitedExceeded = ConnectionProviderError.limitExceeded(nil)
+        connection.handleError(error: connectionLevelLimitedExceeded)
+        wait(for: [failedEvent], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .subscribed)
+        XCTAssertNotNil(connectionProvider.listener)
+    }
+
+    func testLimitExceededConnectionLevel_InProgressToNotSubscribed() throws {
+        let connection = AppSyncSubscriptionConnection(provider: connectionProvider)
+        let connectedMessageExpectation = expectation(description: "Connected event should be fired")
+        let failedEvent = expectation(description: "Failed event should be fired")
+        _ = connection.subscribe(requestString: mockRequestString, variables: variables) { event, _ in
+            switch event {
+            case .connection(let status):
+                if status == .connected {
+                    connectedMessageExpectation.fulfill()
+                }
+            case .data:
+                XCTFail("Data event should not be published")
+            case .failed(let error):
+                guard let connection = error as? ConnectionProviderError,
+                      case .limitExceeded(let id) = connection,
+                      id == nil else {
+                          XCTFail("Should be .limitExceeded(nil)")
+                          return
+                }
+                failedEvent.fulfill()
+            }
+        }
+        wait(for: [connectedMessageExpectation], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .subscribed)
+        XCTAssertNotNil(connectionProvider.listener)
+
+        connection.subscriptionState = .inProgress
+
+        let connectionLevelLimitedExceeded = ConnectionProviderError.limitExceeded(nil)
+        connection.handleError(error: connectionLevelLimitedExceeded)
+        wait(for: [failedEvent], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .notSubscribed)
+        XCTAssertNil(connectionProvider.listener)
+    }
+
+    func testConnection() throws {
+        let connection = AppSyncSubscriptionConnection(provider: connectionProvider)
+        let connectedMessageExpectation = expectation(description: "Connected event should be fired")
+        let failedEvent = expectation(description: "Failed event should be fired")
+        _ = connection.subscribe(requestString: mockRequestString, variables: variables) { event, _ in
+            switch event {
+            case .connection(let status):
+                if status == .connected {
+                    connectedMessageExpectation.fulfill()
+                }
+            case .data:
+                XCTFail("Data event should not be published")
+            case .failed(let error):
+                guard let connection = error as? ConnectionProviderError,
+                      case .connection = connection else {
+                          XCTFail("Should be .connection")
+                          return
+                }
+                failedEvent.fulfill()
+            }
+        }
+        wait(for: [connectedMessageExpectation], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .subscribed)
+        XCTAssertNotNil(connectionProvider.listener)
+
+        let connectionError = ConnectionProviderError.connection
+        connection.handleError(error: connectionError)
+        wait(for: [failedEvent], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .notSubscribed)
+        XCTAssertNil(connectionProvider.listener)
+    }
+
+    func testOther() throws {
+        let connection = AppSyncSubscriptionConnection(provider: connectionProvider)
+        let connectedMessageExpectation = expectation(description: "Connected event should be fired")
+        let failedEvent = expectation(description: "Failed event should be fired")
+        _ = connection.subscribe(requestString: mockRequestString, variables: variables) { event, _ in
+            switch event {
+            case .connection(let status):
+                if status == .connected {
+                    connectedMessageExpectation.fulfill()
+                }
+            case .data:
+                XCTFail("Data event should not be published")
+            case .failed(let error):
+                guard let connection = error as? ConnectionProviderError,
+                      case .other = connection else {
+                          XCTFail("Should be .other")
+                          return
+                }
+                failedEvent.fulfill()
+            }
+        }
+        wait(for: [connectedMessageExpectation], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .subscribed)
+        XCTAssertNotNil(connectionProvider.listener)
+
+        let otherError = ConnectionProviderError.other
+        connection.handleError(error: otherError)
+        wait(for: [failedEvent], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .notSubscribed)
+        XCTAssertNil(connectionProvider.listener)
+    }
+
+    func testRetry() {
+        let connection = AppSyncSubscriptionConnection(provider: connectionProvider)
+        connection.addRetryHandler(handler: TestConnectionRetryHandler(maxCount: 0))
+        let connectedExpectation = expectation(description: "Connected event should be fired")
+        let connectedOnRetryExpectation = expectation(description: "Connected event should be fired")
+        var connectedOnce = false
+        let failedEvent = expectation(description: "Failed event should be fired")
+        _ = connection.subscribe(requestString: mockRequestString, variables: variables) { event, _ in
+            switch event {
+            case .connection(let status):
+                if status == .connected {
+                    if !connectedOnce {
+                        connectedOnce = true
+                        connectedExpectation.fulfill()
+                    } else {
+                        connectedOnRetryExpectation.fulfill()
+                    }
+                }
+            case .data:
+                XCTFail("Data event should not be published")
+            case .failed(let error):
+                guard let connection = error as? ConnectionProviderError,
+                      case .connection = connection else {
+                          XCTFail("Should be .connection")
+                          return
+                }
+                failedEvent.fulfill()
+            }
+        }
+        wait(for: [connectedExpectation], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .subscribed)
+        XCTAssertNotNil(connectionProvider.listener)
+
+        let connectionError = ConnectionProviderError.connection
+        connection.handleError(error: connectionError)
+        wait(for: [connectedOnRetryExpectation], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .subscribed)
+        XCTAssertNotNil(connectionProvider.listener)
+
+        connection.handleError(error: connectionError)
+        wait(for: [failedEvent], timeout: 5)
+        XCTAssertEqual(connection.subscriptionState, .notSubscribed)
+        XCTAssertNil(connectionProvider.listener)
+    }
+
+    // MARK: - Helpers
+
+    class TestConnectionRetryHandler: ConnectionRetryHandler {
+        var count: Int = 0
+        let maxCount: Int
+
+        init(maxCount: Int = 10) {
+            self.maxCount = maxCount
+        }
+
+        func shouldRetryRequest(for error: ConnectionProviderError) -> RetryAdvice {
+            if count > maxCount {
+                return TestRetryAdvice(shouldRetry: false)
+            }
+
+            if case .connection = error {
+                self.count += 1
+                return TestRetryAdvice(shouldRetry: true, retryInterval: .seconds(1))
+            }
+            return TestRetryAdvice(shouldRetry: false)
+
+        }
+    }
+
+    struct TestRetryAdvice: RetryAdvice {
+        var shouldRetry: Bool
+
+        var retryInterval: DispatchTimeInterval?
+    }
+}

--- a/AppSyncRealTimeClientTests/ConnectionProvider/AppSyncRealTimeConnection/RealTimeConnectionProviderResponseTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/AppSyncRealTimeConnection/RealTimeConnectionProviderResponseTests.swift
@@ -41,4 +41,24 @@ class RealTimeConnectionProviderResponseTests: XCTestCase {
 
         XCTAssertTrue(response.isMaxSubscriptionReachedError())
     }
+
+    func testIsLimitExceeded_EmptyPayload() throws {
+        let response = RealtimeConnectionProviderResponse(
+            payload: nil,
+            type: .error
+        )
+
+        XCTAssertFalse(response.isLimitExceededError())
+    }
+
+    func testIsLimitExceeded_LimitExceededError() throws {
+        let payload = ["errors": AppSyncJSONValue.object(["errorType": "LimitExceededError"])]
+        let response = RealtimeConnectionProviderResponse(
+            payload: payload,
+            type: .error
+        )
+
+        XCTAssertTrue(response.isLimitExceededError())
+    }
+
 }

--- a/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderHandleErrorTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderHandleErrorTests.swift
@@ -1,0 +1,165 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import AppSyncRealTimeClient
+
+class ConnectionProviderHandleErrorTests: XCTestCase {
+    let url = URL(string: "https://www.appsyncrealtimeclient.test/")!
+    var websocket = MockWebsocketProvider()
+
+    /// Error response is limit exceeded with id
+    /// Should receive ConnectionProviderError.limitExceeded with id
+    func testLimitExceededWithId() {
+        let provider = RealtimeConnectionProvider(url: url, websocket: websocket)
+
+        let subscriptionEvent = expectation(description: "Receieved subscription event")
+        provider.addListener(identifier: "id") { event in
+            guard case .error(let error) = event,
+                  let connectionError = error as? ConnectionProviderError else {
+                      XCTFail("Should have received error event")
+                      return
+            }
+            guard case .limitExceeded(let id) = connectionError else {
+                XCTFail("Should have received .limitExceeded error")
+                return
+            }
+            XCTAssertEqual(id, "id")
+            subscriptionEvent.fulfill()
+        }
+        let payload = ["errors": AppSyncJSONValue.object(["errorType": "LimitExceededError"])]
+        let response = RealtimeConnectionProviderResponse.init(id: "id", payload: payload, type: .error)
+
+        provider.handleError(response: response)
+        wait(for: [subscriptionEvent], timeout: 1)
+    }
+
+    /// Error response is limit exceeded (connection level error without subscription id)
+    /// Should throttle and receive a fraction of ConnectionProviderError.limitExceeded event without id
+    func testLimitExceededMissingIdThrottled() {
+        let provider = RealtimeConnectionProvider(url: url, websocket: websocket)
+        let limitExceededThrottle = expectation(description: "received limit exceeded")
+        limitExceededThrottle.expectedFulfillmentCount = 100
+        let sink = provider.limitExceededSubject.sink { error in
+            guard case .limitExceeded(let id) = error else {
+                XCTFail("Should have received .limitExceeded error")
+                return
+            }
+            XCTAssertNil(id)
+            limitExceededThrottle.fulfill()
+        }
+        let subscriptionEvent = expectation(description: "Receieved subscription event")
+        subscriptionEvent.assertForOverFulfill = false
+        var subscriptionEventCount = 0
+        provider.addListener(identifier: "id") { event in
+            guard case .error(let error) = event,
+                  let connectionError = error as? ConnectionProviderError else {
+                      XCTFail("Should have received error event")
+                      return
+            }
+            guard case .limitExceeded(let id) = connectionError else {
+                XCTFail("Should have received .limitExceeded error")
+                return
+            }
+            XCTAssertNil(id)
+            subscriptionEventCount += 1
+            subscriptionEvent.fulfill()
+        }
+        let payload = ["errors": AppSyncJSONValue.object(["errorType": "LimitExceededError"])]
+        let response = RealtimeConnectionProviderResponse.init(id: nil, payload: payload, type: .error)
+
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            provider.handleError(response: response)
+        }
+
+        wait(for: [subscriptionEvent, limitExceededThrottle], timeout: 1)
+        // The number of subscription events received should be a fraction of the number of throttled events (100)
+        XCTAssertTrue(subscriptionEventCount < 10)
+        sink.cancel()
+    }
+
+    /// Error response is max subscription with subscription id
+    /// Should receive ConnectionProviderError.limitExceeded with id
+    func testMaxSubscriptionReached() {
+        let provider = RealtimeConnectionProvider(url: url, websocket: websocket)
+
+        let subscriptionEvent = expectation(description: "Receieved subscription event")
+        provider.addListener(identifier: "id") { event in
+            guard case .error(let error) = event,
+                  let connectionError = error as? ConnectionProviderError else {
+                      XCTFail("Should have received error event")
+                      return
+            }
+            guard case .limitExceeded(let id) = connectionError else {
+                XCTFail("Should have received .limitExceeded error")
+                return
+            }
+            XCTAssertEqual(id, "id")
+            subscriptionEvent.fulfill()
+        }
+        let payload = ["errors": AppSyncJSONValue.object(["errorType": "MaxSubscriptionsReachedError"])]
+        let response = RealtimeConnectionProviderResponse.init(id: "id", payload: payload, type: .error)
+
+        provider.handleError(response: response)
+        wait(for: [subscriptionEvent], timeout: 1)
+    }
+
+    /// Error response with no indication for which subscription and missing payload
+    /// Should receive ConnectionProviderError.other
+    func testMissingId() throws {
+        let provider = RealtimeConnectionProvider(url: url, websocket: websocket)
+
+        let subscriptionEvent = expectation(description: "Receieved subscription event")
+        provider.addListener(identifier: "id") { event in
+            guard case .error(let error) = event,
+                  let connectionError = error as? ConnectionProviderError else {
+                      XCTFail("Should have received error event")
+                      return
+            }
+            guard case .other = connectionError else {
+                XCTFail("Should have received .other error")
+                return
+            }
+
+            subscriptionEvent.fulfill()
+        }
+        let response = RealtimeConnectionProviderResponse.init(id: nil, payload: nil, type: .error)
+
+        provider.handleError(response: response)
+        wait(for: [subscriptionEvent], timeout: 1)
+    }
+
+    /// Error response subscription id and payload
+    /// Should receive ConnectionProviderError.subscription(id, payload)
+    func testWithSubscriptionId() throws {
+        let provider = RealtimeConnectionProvider(url: url, websocket: websocket)
+
+        let subscriptionEvent = expectation(description: "Receieved subscription event")
+        provider.addListener(identifier: "id") { event in
+            guard case .error(let error) = event,
+                  let connectionError = error as? ConnectionProviderError else {
+                      XCTFail("Should have received error event")
+                      return
+            }
+            guard case .subscription(let id, let payload) = connectionError else {
+                XCTFail("Should have received .subscription error")
+                return
+            }
+            XCTAssertEqual(id, "id")
+            XCTAssertNotNil(payload)
+            subscriptionEvent.fulfill()
+        }
+        let response = RealtimeConnectionProviderResponse.init(
+            id: "id",
+            payload: ["errorType": "SomeError"],
+            type: .error
+        )
+
+        provider.handleError(response: response)
+        wait(for: [subscriptionEvent], timeout: 1)
+    }
+}

--- a/AppSyncRealTimeClientTests/Mocks/MockWebsocketProvider.swift
+++ b/AppSyncRealTimeClientTests/Mocks/MockWebsocketProvider.swift
@@ -15,14 +15,14 @@ class MockWebsocketProvider: AppSyncWebsocketProvider {
 
     var isConnected: Bool
 
-    let onConnect: OnConnect
-    let onDisconnect: OnDisconnect
-    let onWrite: OnWrite
+    let onConnect: OnConnect?
+    let onDisconnect: OnDisconnect?
+    let onWrite: OnWrite?
 
     init(
-        onConnect: @escaping OnConnect,
-        onDisconnect: @escaping OnDisconnect,
-        onWrite: @escaping OnWrite
+        onConnect: OnConnect? = nil,
+        onDisconnect: OnDisconnect? = nil,
+        onWrite: OnWrite? = nil
     ) {
         self.isConnected = false
         self.onConnect = onConnect
@@ -31,15 +31,15 @@ class MockWebsocketProvider: AppSyncWebsocketProvider {
     }
 
     func connect(url: URL, protocols: [String], delegate: AppSyncWebsocketDelegate?) {
-        onConnect(url, protocols, delegate)
+        onConnect?(url, protocols, delegate)
     }
 
     func disconnect() {
-        onDisconnect()
+        onDisconnect?()
     }
 
     func write(message: String) {
-        onWrite(message)
+        onWrite?(message)
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The LimitExceeded error is received when AppSync throttles the client for making too many subscription requests:
```
{"type":"error","payload":{"errors":{"errorType":"LimitExceededError","message":"Rate limit exceeded"}}}
```

This happens once the rate of subscribes has exceeded the limit on AppSync. Since 100 subscriptions can be established successfully, a loop with 200 or more subscriptions requests will reproduce this.

Consider the current flow

```mermaid

flowchart
A[AppSync] --> |sends LimitExceeded| B[Websocket client];
B --> |convert to ConnectionProviderError.other| C1[Subscription1 - subscribed];
B --> |convert to ConnectionProviderError.other| C2[Subscription2 - not subscribed];
C1 --> |resultHandler error| D[Caller];
C2 --> |resultHandler error| D;
```

1. Subscribe 200 times, 100 will be successfully connected. 101th and onward would get  `MaxSubscriptionsReachedError(subscriptionId)` (and go into retry logic). But, when sending 101st to 200th subscription requests all at the same time, AppSync throttles this client with error `LimitExceededError`. 
2. `LimitExceededError` is received, translate this to a generic `ConnectionProviderError.other` because there's no `id` in the response object. Send `ConnectionProviderError.other` to all 200 subscriptions (even the subscribed ones).
3. All subscriptions will transition to `.notSubscribed` and return a failed event to the caller. Let's say 100 out of 200 subscriptions are throttled, then all 200 subscriptions will get a callback for each error, which is 20000 callbacks. Even though we removed the listener from the connection provider in the previous PR https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/74 , the problem is that connection makes a copy of the subscription listeners before broadcasting the message, so even though they are being removed after sending the error from a previous subscription, they continue to emit a failed message. In normal message rates, removing the connection is enough to do the job.

### How should we handle `LimitExceededError`?

1. The connection receives a `LimitExceededError` without `id` (w/o subscription id - we'll treat this as a connection level LimitExceededError.). Convert it over to `.limitExceeded(nil)` error.
2. Pass it to a client side throttle to slow down the rate at which subscriptions will receive this error.
3. Throttle for 150 ms, and then pass it to the subscriptions.
4. A subscribed subscripiton will ignore this error. 
5. An in progress subscription will return the failure. 

```mermaid
flowchart
A[AppSync] --> |sends LimitExceeded| B[Websocket client];
B --> |convert to ConnectionProviderError.limitExceeded w/ nil| C[Throttle];
C --> |send throttled limitExceeded error| C1[Subscription1 - subscribed];
C --> |send throttled limitExceeded error| C2[Subscription2 - notSubscribed];
C1 --> D[no-op];
C2 --> |resultHandler error| E[Caller];
```

## Manual testing

When subscribing to 500 subscriptions, 100 are connected successfully, 400 failed events. Send a mutation, 100 subscription events are received.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
