### PR TITLE
feat: Allow setting log level

### DIFF
--- a/AppSyncRealTimeClient.xcodeproj/project.pbxproj
+++ b/AppSyncRealTimeClient.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0B59161BB37D32073E4FD61B /* Pods_AppSyncRTCSample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CF486070B34EFD15B4DB8FC /* Pods_AppSyncRTCSample.framework */; };
 		2143D46727B5D9B40066B2F7 /* RealTimeConnectionProviderResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2143D46627B5D9B40066B2F7 /* RealTimeConnectionProviderResponseTests.swift */; };
+		2143D4B027BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2143D4AF27BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift */; };
 		2164E65D2639AD5600385027 /* StarscreamAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164E65C2639AD5600385027 /* StarscreamAdapterTests.swift */; };
 		2164E674263C58CE00385027 /* AppSyncRealTimeClientTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164E673263C58CD00385027 /* AppSyncRealTimeClientTestBase.swift */; };
 		217F39992405D9D500F1A0B3 /* AppSyncRealTimeClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 217F398F2405D9D500F1A0B3 /* AppSyncRealTimeClient.framework */; };
@@ -123,6 +124,7 @@
 /* Begin PBXFileReference section */
 		18D6E56CE03BAC33493CC19B /* Pods-HostApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp.debug.xcconfig"; path = "Target Support Files/Pods-HostApp/Pods-HostApp.debug.xcconfig"; sourceTree = "<group>"; };
 		2143D46627B5D9B40066B2F7 /* RealTimeConnectionProviderResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealTimeConnectionProviderResponseTests.swift; sourceTree = "<group>"; };
+		2143D4AF27BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncRealTimeClient.swift; sourceTree = "<group>"; };
 		2164E65C2639AD5600385027 /* StarscreamAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarscreamAdapterTests.swift; sourceTree = "<group>"; };
 		2164E673263C58CD00385027 /* AppSyncRealTimeClientTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientTestBase.swift; sourceTree = "<group>"; };
 		217F398F2405D9D500F1A0B3 /* AppSyncRealTimeClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AppSyncRealTimeClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -302,9 +304,10 @@
 		217F39912405D9D500F1A0B3 /* AppSyncRealTimeClient */ = {
 			isa = PBXGroup;
 			children = (
-				217F39932405D9D500F1A0B3 /* Info.plist */,
+				2143D4AF27BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift */,
 				217F39B82406E98300F1A0B3 /* Connection */,
 				217F39A92406E98300F1A0B3 /* ConnectionProvider */,
+				217F39932405D9D500F1A0B3 /* Info.plist */,
 				21D38B6E240A272F00EC2A8D /* Interceptor */,
 				217F39C62406E98400F1A0B3 /* Support */,
 				217F39C12406E98400F1A0B3 /* Websocket */,
@@ -1120,6 +1123,7 @@
 				217F39DD2406E98400F1A0B3 /* AppSyncSubscriptionConnection+Connection.swift in Sources */,
 				217F39E52406E98400F1A0B3 /* AppSyncJSONValue.swift in Sources */,
 				217F39E42406E98400F1A0B3 /* RealtimeGatewayURLInterceptor.swift in Sources */,
+				2143D4B027BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift in Sources */,
 				217F39E22406E98400F1A0B3 /* StarscreamAdapter+Delegate.swift in Sources */,
 				217F39D52406E98400F1A0B3 /* RealtimeConnectionProviderResponse.swift in Sources */,
 				217F39D62406E98400F1A0B3 /* RealtimeConnectionProvider+MessageInterceptable.swift in Sources */,

--- a/AppSyncRealTimeClient/AWSAppSyncRealTimeClient.swift
+++ b/AppSyncRealTimeClient/AWSAppSyncRealTimeClient.swift
@@ -1,0 +1,44 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public enum AppSyncRealTimeClient {
+
+    static let lock: NSLocking = NSLock()
+
+    static var _logLevel = LogLevel.error // swiftlint:disable:this identifier_name
+
+    public static var logLevel: LogLevel {
+        get {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+
+            return _logLevel
+        }
+        set {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+
+            _logLevel = newValue
+        }
+    }
+}
+
+public extension AppSyncRealTimeClient {
+    enum LogLevel: Int {
+        case error
+        case warn
+        case info
+        case debug
+        case verbose
+    }
+}

--- a/AppSyncRealTimeClient/Support/AppSyncLogger.swift
+++ b/AppSyncRealTimeClient/Support/AppSyncLogger.swift
@@ -10,41 +10,14 @@ import os
 
 struct AppSyncLogger {
 
+    static var logLevel: AppSyncRealTimeClient.LogLevel {
+        AppSyncRealTimeClient.logLevel
+    }
+
     static func error(_ log: String) {
+        // Always logged, no conditional check needed
         if #available(iOS 10.0, *) {
             os_log("%@", type: .error, log)
-        } else {
-            NSLog("%@", log)
-        }
-    }
-
-    static func debug(_ log: String) {
-        if #available(iOS 10.0, *) {
-            os_log("%@", type: .debug, log)
-        } else {
-            NSLog("%@", log)
-        }
-    }
-
-    static func verbose(_ log: String) {
-        if #available(iOS 10.0, *) {
-            os_log("%@", type: .debug, log)
-        } else {
-            NSLog("%@", log)
-        }
-    }
-
-    static func info(_ log: String) {
-        if #available(iOS 10.0, *) {
-            os_log("%@", type: .info, log)
-        } else {
-            NSLog("%@", log)
-        }
-    }
-
-    static func warn(_ log: String) {
-        if #available(iOS 10.0, *) {
-            os_log("%@", type: .info, log)
         } else {
             NSLog("%@", log)
         }
@@ -55,6 +28,54 @@ struct AppSyncLogger {
             os_log("%@", type: .error, error.localizedDescription)
         } else {
             NSLog("%@", error.localizedDescription)
+        }
+    }
+
+    static func warn(_ log: String) {
+        guard logLevel.rawValue >= AppSyncRealTimeClient.LogLevel.warn.rawValue else {
+            return
+        }
+
+        if #available(iOS 10.0, *) {
+            os_log("%@", type: .info, log)
+        } else {
+            NSLog("%@", log)
+        }
+    }
+
+    static func info(_ log: String) {
+        guard logLevel.rawValue >= AppSyncRealTimeClient.LogLevel.info.rawValue else {
+            return
+        }
+
+        if #available(iOS 10.0, *) {
+            os_log("%@", type: .info, log)
+        } else {
+            NSLog("%@", log)
+        }
+    }
+
+    static func debug(_ log: String) {
+        guard logLevel.rawValue >= AppSyncRealTimeClient.LogLevel.debug.rawValue else {
+            return
+        }
+
+        if #available(iOS 10.0, *) {
+            os_log("%@", type: .debug, log)
+        } else {
+            NSLog("%@", log)
+        }
+    }
+
+    static func verbose(_ log: String) {
+        guard logLevel.rawValue >= AppSyncRealTimeClient.LogLevel.verbose.rawValue else {
+            return
+        }
+
+        if #available(iOS 10.0, *) {
+            os_log("%@", type: .debug, log)
+        } else {
+            NSLog("%@", log)
         }
     }
 }

--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientTestBase.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientTestBase.swift
@@ -23,6 +23,7 @@ class AppSyncRealTimeClientTestBase: XCTestCase {
         """
 
     override func setUp() {
+        AppSyncRealTimeClient.logLevel = .verbose
         do {
             let json = try ConfigurationHelper.retrieve(forResource: "amplifyconfiguration")
             if let data = json as? [String: Any],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allow the logging level to be configurable allows the consumers of this package (API Plugin and AppSync SDK) to set it through its log level. In Amplify, when the developer sets `Amplify.Logging.logLevel`, this can be propagated to `AppSyncRealTimeClient.logLevel` when the plugins are configured. Since the intention is to propagate the log levels from Amplify, they are identical to the ones defined in Amplify.Logging category https://github.com/aws-amplify/amplify-ios/blob/main/Amplify/Categories/Logging/LogLevel.swift

```swift
enum LogLevel: Int {
        case error
        case warn
        case info
        case debug
        case verbose
    }
```

- errors is the default log level (also is Amplify's)
- the log level can be set with `AppSyncRealTimeClient.logLevel = .verbose` by developers after calling `Amplify.configure` if they are debugging and want the logLevels to be different from Amplify.Logging's logLevel, though i don't think this is a very common use case, as developers should just be operating on `Amplify.Logging.logLevel`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
