### PR TITLE
fix: Subscription failed event should be terminal event

### DIFF
--- a/AppSyncRealTimeClient.xcodeproj/project.pbxproj
+++ b/AppSyncRealTimeClient.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0B59161BB37D32073E4FD61B /* Pods_AppSyncRTCSample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CF486070B34EFD15B4DB8FC /* Pods_AppSyncRTCSample.framework */; };
 		2143D46727B5D9B40066B2F7 /* RealTimeConnectionProviderResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2143D46627B5D9B40066B2F7 /* RealTimeConnectionProviderResponseTests.swift */; };
 		2143D4B027BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2143D4AF27BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift */; };
+		2143D4B227BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2143D4B127BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift */; };
 		2164E65D2639AD5600385027 /* StarscreamAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164E65C2639AD5600385027 /* StarscreamAdapterTests.swift */; };
 		2164E674263C58CE00385027 /* AppSyncRealTimeClientTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164E673263C58CD00385027 /* AppSyncRealTimeClientTestBase.swift */; };
 		217F39992405D9D500F1A0B3 /* AppSyncRealTimeClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 217F398F2405D9D500F1A0B3 /* AppSyncRealTimeClient.framework */; };
@@ -125,6 +126,7 @@
 		18D6E56CE03BAC33493CC19B /* Pods-HostApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp.debug.xcconfig"; path = "Target Support Files/Pods-HostApp/Pods-HostApp.debug.xcconfig"; sourceTree = "<group>"; };
 		2143D46627B5D9B40066B2F7 /* RealTimeConnectionProviderResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealTimeConnectionProviderResponseTests.swift; sourceTree = "<group>"; };
 		2143D4AF27BC49BE0066B2F7 /* AWSAppSyncRealTimeClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncRealTimeClient.swift; sourceTree = "<group>"; };
+		2143D4B127BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientFailureTests.swift; sourceTree = "<group>"; };
 		2164E65C2639AD5600385027 /* StarscreamAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarscreamAdapterTests.swift; sourceTree = "<group>"; };
 		2164E673263C58CD00385027 /* AppSyncRealTimeClientTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientTestBase.swift; sourceTree = "<group>"; };
 		217F398F2405D9D500F1A0B3 /* AppSyncRealTimeClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AppSyncRealTimeClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -455,6 +457,7 @@
 			isa = PBXGroup;
 			children = (
 				21D38B4B2409B6C000EC2A8D /* amplifyconfiguration.json */,
+				2143D4B127BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift */,
 				21D38B402409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests.swift */,
 				2164E673263C58CD00385027 /* AppSyncRealTimeClientTestBase.swift */,
 				21D38B422409AFBD00EC2A8D /* Info.plist */,
@@ -1176,6 +1179,7 @@
 				21D38B99240C4E1C00EC2A8D /* ConfigurationHelper.swift in Sources */,
 				2164E674263C58CE00385027 /* AppSyncRealTimeClientTestBase.swift in Sources */,
 				21D38B97240C4DCF00EC2A8D /* Error+Extension.swift in Sources */,
+				2143D4B227BE40B30066B2F7 /* AppSyncRealTimeClientFailureTests.swift in Sources */,
 				21D38B9D240C540D00EC2A8D /* TestCommonConstants.swift in Sources */,
 				21D38B412409AFBD00EC2A8D /* AppSyncRealTimeClientIntegrationTests.swift in Sources */,
 				2164E65D2639AD5600385027 /* StarscreamAdapterTests.swift in Sources */,

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+Connection.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+Connection.swift
@@ -31,7 +31,7 @@ extension AppSyncSubscriptionConnection {
         else {
             return
         }
-        AppSyncLogger.debug("[AppSyncSubscriptionConnection] \(#function): connection is connected, start subscription.")
+        AppSyncLogger.debug("[AppSyncSubscriptionConnection]: Connection connected, start subscription \(subscriptionItem.identifier).")
         subscriptionState = .inProgress
 
         guard let payload = convertToPayload(

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+ErrorHandler.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection+ErrorHandler.swift
@@ -32,6 +32,7 @@ extension AppSyncSubscriptionConnection {
             let connectionError = error as? ConnectionProviderError
         else {
             subscriptionItem.subscriptionEventHandler(.failed(error), subscriptionItem)
+            connectionProvider?.removeListener(identifier: subscriptionItem.identifier)
             return
         }
 
@@ -43,6 +44,7 @@ extension AppSyncSubscriptionConnection {
             }
         } else {
             subscriptionItem.subscriptionEventHandler(.failed(error), subscriptionItem)
+            connectionProvider?.removeListener(identifier: subscriptionItem.identifier)
         }
     }
 

--- a/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
+++ b/AppSyncRealTimeClient/Connection/AppSyncConnection/AppSyncSubscriptionConnection.swift
@@ -81,7 +81,7 @@ public class AppSyncSubscriptionConnection: SubscriptionConnection, RetryableCon
 
         connectionProvider.addListener(identifier: subscriptionItem.identifier) { [weak self] event in
             guard let self = self else {
-                AppSyncLogger.debug("[AppSyncSubscriptionConnection] \(#function): Self is nil, listener is not called.")
+                AppSyncLogger.debug("[AppSyncSubscriptionConnection]: Subscription (Self) is nil, connection event is not handled.")
                 return
             }
             switch event {

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+StaleConnection.swift
@@ -21,7 +21,7 @@ extension RealtimeConnectionProvider {
 
     /// Reset the stale connection timer in response to receiving a message from the websocket
     func resetStaleConnectionTimer(interval: TimeInterval? = nil) {
-        AppSyncLogger.debug("[RealtimeConnectionProvider] Resetting stale connection timer")
+        AppSyncLogger.verbose("[RealtimeConnectionProvider] Resetting stale connection timer")
         staleConnectionTimer.reset(interval: interval)
     }
 

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
@@ -53,7 +53,7 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
                 self?.handleConnectionAck(response: response)
             }
         case .error:
-            AppSyncLogger.debug("[RealtimeConnectionProvider] received error")
+            AppSyncLogger.verbose("[RealtimeConnectionProvider] received error")
             connectionQueue.async { [weak self] in
                 self?.handleError(response: response)
             }
@@ -62,7 +62,7 @@ extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
                 updateCallback(event: .data(appSyncResponse))
             }
         case .keepAlive:
-            AppSyncLogger.debug("[RealtimeConnectionProvider] received keepAlive")
+            AppSyncLogger.verbose("[RealtimeConnectionProvider] received keepAlive")
         }
     }
 

--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientFailureTests.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientFailureTests.swift
@@ -1,0 +1,190 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import AppSyncRealTimeClient
+
+class AppSyncRealTimeClientFailureTests: AppSyncRealTimeClientTestBase {
+
+    /// Test the current AppSync limit of 100 subscriptions per connection
+    func testMaxSubscriptionReached() {
+        let subscribeSuccess = expectation(description: "subscribe successfully")
+        subscribeSuccess.expectedFulfillmentCount = 100
+        let authInterceptor = APIKeyAuthInterceptor(apiKey)
+        let connectionProvider = ConnectionProviderFactory.createConnectionProvider(
+            for: url,
+            authInterceptor: authInterceptor,
+            connectionType: .appSyncRealtime
+        )
+        var subscriptions = [AppSyncSubscriptionConnection]()
+        for _ in 1 ... 100 {
+            let subscription = AppSyncSubscriptionConnection(provider: connectionProvider)
+            _ = subscription.subscribe(
+                requestString: requestString,
+                variables: nil
+            ) { event, _ in
+                switch event {
+                case .connection(let subscriptionConnectionEvent):
+                    switch subscriptionConnectionEvent {
+                    case .connecting:
+                        break
+                    case .connected:
+                        subscribeSuccess.fulfill()
+                    case .disconnected:
+                        break
+                    }
+                case .data(let data):
+                    print("Got data back \(data)")
+                case .failed(let error):
+                    XCTFail("Got error \(error)")
+                }
+            }
+            subscriptions.append(subscription)
+        }
+
+        wait(for: [subscribeSuccess], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertEqual(subscriptions.count, 100)
+        let limitExceeded = expectation(description: "Received Limit Exceeded error")
+        let subscription = AppSyncSubscriptionConnection(provider: connectionProvider)
+        _ = subscription.subscribe(
+            requestString: requestString,
+            variables: nil
+        ) { event, _ in
+            switch event {
+            case .connection(let subscriptionConnectionEvent):
+                switch subscriptionConnectionEvent {
+                case .connecting:
+                    break
+                case .connected:
+                    XCTFail("Got connected successfully - Should have been limit exceeded")
+                case .disconnected:
+                    break
+                }
+            case .data(let data):
+                print("Got data back \(data)")
+            case .failed(let error):
+                guard let connectionError = error as? ConnectionProviderError,
+                      case .limitExceeded = connectionError else {
+                          XCTFail("Should Be Limited Exceeded error")
+                          return
+                }
+
+                limitExceeded.fulfill()
+            }
+        }
+        wait(for: [limitExceeded], timeout: TestCommonConstants.networkTimeout)
+
+        for subscription in subscriptions {
+            if let item = subscription.subscriptionItem {
+                subscription.unsubscribe(item: item)
+            }
+        }
+    }
+
+    /// Subscriptions receiving a failed event should only receive it once.
+    func testMaxSubscriptionReachedWithRetry() {
+        let subscribeSuccess = expectation(description: "subscribe successfully")
+        subscribeSuccess.expectedFulfillmentCount = 100
+        let authInterceptor = APIKeyAuthInterceptor(apiKey)
+        let connectionProvider = ConnectionProviderFactory.createConnectionProvider(
+            for: url,
+            authInterceptor: authInterceptor,
+            connectionType: .appSyncRealtime
+        )
+        var subscriptions = [AppSyncSubscriptionConnection]()
+        for _ in 1 ... 100 {
+            let subscription = AppSyncSubscriptionConnection(provider: connectionProvider)
+            _ = subscription.subscribe(
+                requestString: requestString,
+                variables: nil
+            ) { event, _ in
+                switch event {
+                case .connection(let subscriptionConnectionEvent):
+                    switch subscriptionConnectionEvent {
+                    case .connecting:
+                        break
+                    case .connected:
+                        subscribeSuccess.fulfill()
+                    case .disconnected:
+                        break
+                    }
+                case .data(let data):
+                    print("Got data back \(data)")
+                case .failed(let error):
+                    XCTFail("Got error \(error)")
+                }
+            }
+            subscriptions.append(subscription)
+        }
+
+        wait(for: [subscribeSuccess], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertEqual(subscriptions.count, 100)
+        let limitExceeded = expectation(description: "Received Limit Exceeded error")
+        limitExceeded.expectedFulfillmentCount = 2
+        for _ in 1 ... 2 {
+            let subscription = AppSyncSubscriptionConnection(provider: connectionProvider)
+            subscription.addRetryHandler(handler: TestConnectionRetryHandler())
+            _ = subscription.subscribe(
+                requestString: requestString,
+                variables: nil
+            ) { event, _ in
+                switch event {
+                case .connection(let subscriptionConnectionEvent):
+                    switch subscriptionConnectionEvent {
+                    case .connecting:
+                        break
+                    case .connected:
+                        XCTFail("Got connected successfully - Should have been limit exceeded")
+                    case .disconnected:
+                        break
+                    }
+                case .data(let data):
+                    print("Got data back \(data)")
+                case .failed(let error):
+                    guard let connectionError = error as? ConnectionProviderError,
+                          case .limitExceeded = connectionError else {
+                              XCTFail("Should Be Limited Exceeded error")
+                              return
+                    }
+
+                    limitExceeded.fulfill()
+                }
+            }
+            subscriptions.append(subscription)
+        }
+
+        wait(for: [limitExceeded], timeout: TestCommonConstants.networkTimeout)
+
+        for subscription in subscriptions {
+            if let item = subscription.subscriptionItem {
+                subscription.unsubscribe(item: item)
+            }
+        }
+    }
+
+    class TestConnectionRetryHandler: ConnectionRetryHandler {
+        var count: Int = 0
+        func shouldRetryRequest(for error: ConnectionProviderError) -> RetryAdvice {
+            if count > 10 {
+                return TestRetryAdvice(shouldRetry: false)
+            }
+
+            if case .limitExceeded = error {
+                self.count += 1
+                return TestRetryAdvice(shouldRetry: true, retryInterval: .seconds(1))
+            }
+            return TestRetryAdvice(shouldRetry: false)
+
+        }
+    }
+
+    struct TestRetryAdvice: RetryAdvice {
+        var shouldRetry: Bool
+
+        var retryInterval: DispatchTimeInterval?
+    }
+}

--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientTestBase.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientTestBase.swift
@@ -23,7 +23,7 @@ class AppSyncRealTimeClientTestBase: XCTestCase {
         """
 
     override func setUp() {
-        AppSyncRealTimeClient.logLevel = .verbose
+        AppSyncRealTimeClient.logLevel = .debug
         do {
             let json = try ConfigurationHelper.retrieve(forResource: "amplifyconfiguration")
             if let data = json as? [String: Any],

--- a/AppSyncRealTimeClientTests/Connection/AppSyncSubscriptionConnectionTests.swift
+++ b/AppSyncRealTimeClientTests/Connection/AppSyncSubscriptionConnectionTests.swift
@@ -59,6 +59,7 @@ class AppSyncSubscriptionConnectionTests: XCTestCase {
         }
         XCTAssertNotNil(item, "Subscription item should not be nil")
         wait(for: [connectingMessageExpectation, connectedMessageExpectation], timeout: 5, enforceOrder: true)
+        XCTAssertNotNil(connectionProvider.listener)
     }
 
     /// Test unsubscribe subscription gives us back the right events
@@ -101,8 +102,10 @@ class AppSyncSubscriptionConnectionTests: XCTestCase {
         XCTAssertNotNil(item, "Subscription item should not be nil")
         wait(for: [connectingMessageExpectation, connectedMessageExpectation], timeout: 5, enforceOrder: true)
 
+        XCTAssertNotNil(connectionProvider.listener)
         connection.unsubscribe(item: item)
         wait(for: [unsubscribeAckExpectation], timeout: 2)
+        XCTAssertNil(connectionProvider.listener)
     }
 
     /// Test subscription with invalid connection
@@ -141,6 +144,7 @@ class AppSyncSubscriptionConnectionTests: XCTestCase {
         }
         XCTAssertNotNil(item, "Subscription item should not be nil")
         wait(for: [connectingMessageExpectation, errorEventExpectation], timeout: 5, enforceOrder: true)
+        XCTAssertNil(connectionProvider.listener)
     }
 
     /// Test if trying to subscribe with a 'not connected' connection gives error
@@ -181,6 +185,7 @@ class AppSyncSubscriptionConnectionTests: XCTestCase {
         }
         XCTAssertNotNil(item, "Subscription item should not be nil")
         wait(for: [connectingMessageExpectation, errorEventExpectation], timeout: 5, enforceOrder: true)
+        XCTAssertNil(connectionProvider.listener)
     }
 
     /// Test if valid data is returned
@@ -230,6 +235,7 @@ class AppSyncSubscriptionConnectionTests: XCTestCase {
         )
         connectionProvider.sendDataResponse(mockResponse)
         wait(for: [dataEventExpectation], timeout: 2)
+        XCTAssertNotNil(connectionProvider.listener)
     }
 
     func testNilDataInVariables() {
@@ -261,6 +267,7 @@ class AppSyncSubscriptionConnectionTests: XCTestCase {
         }
         XCTAssertNotNil(item, "Subscription item should not be nil")
         wait(for: [connectingMessageExpectation, connectedMessageExpectation], timeout: 5, enforceOrder: true)
+        XCTAssertNotNil(connectionProvider.listener)
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The caller of a subscription should only receive the `.failed` event once. A `.failed` event to the caller indicates that the subscription is in terminal state. In AppSync SDK, this event is propagated back to the caller in the resultHandler. In APIPlugin, this is in the completionListener. Data/Connection events are propagated in a different handler (statusHandler, progressHandler). 

The bug is that the subscription will send multiple `.failed` events in a few scenarios. 
1. Subscription level messages (messages with the exact subscription ID) will be sent to all subscriptions and filtered out by other subscriptions. Errors are handled by sending the `.failed` event.
2. Connection level messages will be sent to all subscriptions, the subscription will handle errors by sending the `.failed` event. 
Multiple `.failed` events can be caused by a combination of 1 and 2 or multiple instances of 1 or 2. The below scenario describes one scenario where there are multiple instances of 1. The 101st subscription reaches terminal state, and then the 102nd subscription causes subscription 101 to retry and send another `.failed` event to the caller.

### MaxSubscriptionReached failure scenario

When there are 100 subscriptions subscribed to the connection, the 101st subscription will fail with MaxSubscriptionsReached and retry, and eventually the caller will receive the subscription failed to subscribe.

```mermaid
flowchart 
A[101st Subscription receives MaxSubscriptionReached] --> B{Retry Advice - Should retry?};
B -- Yes --> C[Connection.connect];
B -- No --> D[Send Failed event];
D ----> E[Caller];
C --> F[First 100 Subscriptions];
C --> G[101st Subscription];
F --> H[Already subscribed, No-op];
G --> I[Not subscribed, subscribe];
I --> A
```

When both 101st and 102nd subscriptions fail with MaxSubscriptionsReached, they both wait for retry to trigger. When retry is triggered, it will call Connection.connect. The connection will inform every subscription to handle the connected status. The first 100 subscriptions will ignore the connection event since they are already subscribed.

```mermaid

flowchart 
Z[Connection.receive] -->|MaxSubscriptionReached Sub 101| A[Sub 101 - .inProgress];
Z[Connection.receive] -->|MaxSubscriptionReached Sub 102| B[Sub 102 - .inProgress];
A --> A2[Sub 101 to .notSubscribed - Waiting for retry];
B --> B2[Sub 102 to .notSubscribed - Waiting for retry];
B2 --> |retry fired| A4[Call connection.connect];
A2 --> |retry fired| A4[Call Connection.connect];
A4 --> |send connected event|A5[Sub id 101 to inProgress];
A4 --> |send connected event|A6[Sub id 102 to inProgress];
A5 -->|send subscribe| Z2[Connection.write message]
A6 -->|send subscribe| Z2[Connection.write message]
```

When both subscriptions for waiting to retry, one of them will fire before the other. Say subscription 101 fires slightly before subscription 102, while 102 is still waiting to fire. 101's retry attempt causes both 101 and 102 to retry. Because 102 is attempting earlier than it should, it's retry attempts are exhausted first. One way to see this is to wait for 101 to retry a few times until it reaches a long wait time, then start 102 on its retry path.
```
[LAWMICHA] Connecting Sub 101 (8B930D03-B707-4C1F-A44A-CF867D69047C)
2022-02-17 02:38:27.687731-0500 AppSyncSample[49746:9568800] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(217)
2022-02-17 02:38:28.040812-0500 AppSyncSample[49746:9568534] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(476)
2022-02-17 02:38:28.678885-0500 AppSyncSample[49746:9568532] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(884)
2022-02-17 02:38:29.773876-0500 AppSyncSample[49746:9568534] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(1651)
2022-02-17 02:38:31.718702-0500 AppSyncSample[49746:9568532] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(3284)
2022-02-17 02:38:35.445070-0500 AppSyncSample[49746:9568534] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(6418)
2022-02-17 02:38:42.636133-0500 AppSyncSample[49746:9569644] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(12889)
2022-02-17 02:38:57.037133-0500 AppSyncSample[49746:9569848] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(25600)
[LAWMICHA] Connecting Sub 102 (7C67C248-04BE-4D15-9486-10E51215FAE4)
2022-02-17 02:39:20.798466-0500 AppSyncSample[49746:9570421] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 notSubscribed.
2022-02-17 02:39:20.798848-0500 AppSyncSample[49746:9570421] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 8B930D03-B707-4C1F-A44A-CF867D69047C notSubscribed.
2022-02-17 02:39:21.050572-0500 AppSyncSample[49746:9570419] ConnectionProviderError.limitExceeded; identifier=7C67C248-04BE-4D15-9486-10E51215FAE4;
2022-02-17 02:39:21.051335-0500 AppSyncSample[49746:9570419] [AppSyncSubscriptionConnection] Retrying subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 after milliseconds(204)
2022-02-17 02:39:21.156638-0500 AppSyncSample[49746:9570443] ConnectionProviderError.limitExceeded; identifier=8B930D03-B707-4C1F-A44A-CF867D69047C;
2022-02-17 02:39:21.157873-0500 AppSyncSample[49746:9570443] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(51266)
2022-02-17 02:39:21.276009-0500 AppSyncSample[49746:9570420] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 notSubscribed.
2022-02-17 02:39:21.276328-0500 AppSyncSample[49746:9570420] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 8B930D03-B707-4C1F-A44A-CF867D69047C notSubscribed.
2022-02-17 02:39:21.443558-0500 AppSyncSample[49746:9570420] ConnectionProviderError.limitExceeded; identifier=7C67C248-04BE-4D15-9486-10E51215FAE4;
2022-02-17 02:39:21.450886-0500 AppSyncSample[49746:9570420] [AppSyncSubscriptionConnection] Retrying subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 after milliseconds(487)
2022-02-17 02:39:21.545018-0500 AppSyncSample[49746:9570443] ConnectionProviderError.limitExceeded; identifier=8B930D03-B707-4C1F-A44A-CF867D69047C;
2022-02-17 02:39:21.545262-0500 AppSyncSample[49746:9570443] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(102417)
2022-02-17 02:39:21.986469-0500 AppSyncSample[49746:9570443] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 notSubscribed.
2022-02-17 02:39:21.986885-0500 AppSyncSample[49746:9570443] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 8B930D03-B707-4C1F-A44A-CF867D69047C notSubscribed.
2022-02-17 02:39:22.204983-0500 AppSyncSample[49746:9570443] ConnectionProviderError.limitExceeded; identifier=7C67C248-04BE-4D15-9486-10E51215FAE4;
2022-02-17 02:39:22.205540-0500 AppSyncSample[49746:9570443] [AppSyncSubscriptionConnection] Retrying subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 after milliseconds(864)
2022-02-17 02:39:22.310200-0500 AppSyncSample[49746:9570419] ConnectionProviderError.limitExceeded; identifier=8B930D03-B707-4C1F-A44A-CF867D69047C;
2022-02-17 02:39:22.310760-0500 AppSyncSample[49746:9570419] [AppSyncSubscriptionConnection] Retrying subscription 8B930D03-B707-4C1F-A44A-CF867D69047C after milliseconds(204854)
2022-02-17 02:39:23.155564-0500 AppSyncSample[49746:9570419] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 notSubscribed.
2022-02-17 02:39:23.156448-0500 AppSyncSample[49746:9570419] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 8B930D03-B707-4C1F-A44A-CF867D69047C notSubscribed.
2022-02-17 02:39:23.280223-0500 AppSyncSample[49746:9570419] ConnectionProviderError.limitExceeded; identifier=7C67C248-04BE-4D15-9486-10E51215FAE4;
2022-02-17 02:39:23.280678-0500 AppSyncSample[49746:9570419] [AppSyncSubscriptionConnection] Retrying subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 after milliseconds(1604)
2022-02-17 02:39:23.382805-0500 AppSyncSample[49746:9570443] ConnectionProviderError.limitExceeded; identifier=8B930D03-B707-4C1F-A44A-CF867D69047C;
2022-02-17 02:39:23.383237-0500 AppSyncSample[49746:9570443] 8B930D03-B707-4C1F-A44A-CF867D69047C Should not retry, send failure
[LAWMICHA] AppSync subscription error=limitExceeded(Optional("8B930D03-B707-4C1F-A44A-CF867D69047C"))
2022-02-17 02:39:25.043645-0500 AppSyncSample[49746:9570419] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 notSubscribed.
2022-02-17 02:39:25.043851-0500 AppSyncSample[49746:9570419] State 7C67C248-04BE-4D15-9486-10E51215FAE4 inProgress.
2022-02-17 02:39:25.044179-0500 AppSyncSample[49746:9570419] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 8B930D03-B707-4C1F-A44A-CF867D69047C notSubscribed.
2022-02-17 02:39:25.044271-0500 AppSyncSample[49746:9570419] State 8B930D03-B707-4C1F-A44A-CF867D69047C inProgress.
2022-02-17 02:39:25.155548-0500 AppSyncSample[49746:9570443] [RealtimeConnectionProvider] received error
2022-02-17 02:39:25.156578-0500 AppSyncSample[49746:9570443] ConnectionProviderError.limitExceeded; identifier=7C67C248-04BE-4D15-9486-10E51215FAE4;
2022-02-17 02:39:25.157051-0500 AppSyncSample[49746:9570443] [AppSyncSubscriptionConnection] Retrying subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 after milliseconds(3228)
2022-02-17 02:39:25.291440-0500 AppSyncSample[49746:9570443] [RealtimeConnectionProvider] received error
2022-02-17 02:39:25.292583-0500 AppSyncSample[49746:9570420] ConnectionProviderError.limitExceeded; identifier=8B930D03-B707-4C1F-A44A-CF867D69047C;
2022-02-17 02:39:25.293067-0500 AppSyncSample[49746:9570420] 8B930D03-B707-4C1F-A44A-CF867D69047C Should not retry, send failure
[LAWMICHA] AppSync subscription error=limitExceeded(Optional("8B930D03-B707-4C1F-A44A-CF867D69047C"))
2022-02-17 02:39:28.709346-0500 AppSyncSample[49746:9570420] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 notSubscribed.
2022-02-17 02:39:28.709565-0500 AppSyncSample[49746:9570420] State 7C67C248-04BE-4D15-9486-10E51215FAE4 inProgress.
2022-02-17 02:39:28.710093-0500 AppSyncSample[49746:9570420] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 8B930D03-B707-4C1F-A44A-CF867D69047C notSubscribed.
2022-02-17 02:39:28.710197-0500 AppSyncSample[49746:9570420] State 8B930D03-B707-4C1F-A44A-CF867D69047C inProgress.
2022-02-17 02:39:28.822403-0500 AppSyncSample[49746:9570443] [RealtimeConnectionProvider] received error
2022-02-17 02:39:28.823268-0500 AppSyncSample[49746:9570443] ConnectionProviderError.limitExceeded; identifier=7C67C248-04BE-4D15-9486-10E51215FAE4;
2022-02-17 02:39:28.823797-0500 AppSyncSample[49746:9570443] [AppSyncSubscriptionConnection] Retrying subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 after milliseconds(6469)
2022-02-17 02:39:28.934294-0500 AppSyncSample[49746:9570420] [RealtimeConnectionProvider] received error
2022-02-17 02:39:28.934780-0500 AppSyncSample[49746:9570420] ConnectionProviderError.limitExceeded; identifier=8B930D03-B707-4C1F-A44A-CF867D69047C;
2022-02-17 02:39:28.934991-0500 AppSyncSample[49746:9570420] 8B930D03-B707-4C1F-A44A-CF867D69047C Should not retry, send failure
[LAWMICHA] AppSync subscription error=limitExceeded(Optional("8B930D03-B707-4C1F-A44A-CF867D69047C"))
2022-02-17 02:39:35.939546-0500 AppSyncSample[49746:9570420] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 notSubscribed.
2022-02-17 02:39:35.939955-0500 AppSyncSample[49746:9570420] State 7C67C248-04BE-4D15-9486-10E51215FAE4 inProgress.
2022-02-17 02:39:35.940592-0500 AppSyncSample[49746:9570420] [AppSyncSubscriptionConnection] startSubscription(): connection is connected, start subscription 8B930D03-B707-4C1F-A44A-CF867D69047C notSubscribed.
2022-02-17 02:39:35.940842-0500 AppSyncSample[49746:9570420] State 8B930D03-B707-4C1F-A44A-CF867D69047C inProgress.
2022-02-17 02:39:36.051072-0500 AppSyncSample[49746:9569849] [RealtimeConnectionProvider] received error
2022-02-17 02:39:36.052907-0500 AppSyncSample[49746:9569849] ConnectionProviderError.limitExceeded; identifier=7C67C248-04BE-4D15-9486-10E51215FAE4;
2022-02-17 02:39:36.053634-0500 AppSyncSample[49746:9569849] [AppSyncSubscriptionConnection] Retrying subscription 7C67C248-04BE-4D15-9486-10E51215FAE4 after milliseconds(12839)
2022-02-17 02:39:36.163584-0500 AppSyncSample[49746:9570868] [RealtimeConnectionProvider] received error
2022-02-17 02:39:36.164590-0500 AppSyncSample[49746:9570868] ConnectionProviderError.limitExceeded; identifier=8B930D03-B707-4C1F-A44A-CF867D69047C;
2022-02-17 02:39:36.164999-0500 AppSyncSample[49746:9570868] 8B930D03-B707-4C1F-A44A-CF867D69047C Should not retry, send failure
[LAWMICHA] AppSync subscription error=limitExceeded(Optional("8B930D03-B707-4C1F-A44A-CF867D69047C"))
```
Sub 102 causes Sub 101 to retry despite it's retry attempts have been exhausted. The problem is that sub 101 attempted to retry based on another subscriptions retry logic, and that it sent multiple failure events indicating that it failed. 

This PR removes the subscription from the connection so that it will no longer handle connection messages after it has sent out a failed event to the caller. This doesn't solve the problem with cross-subscription fired retry attempts, however, it does have the desired behavior for callers to be able to react properly to the `.failed` event. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
