### PR TITLE
chore: Prep 1.9.0 release

### DIFF
--- a/AppSyncRealTimeClient.podspec
+++ b/AppSyncRealTimeClient.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         = 'AppSyncRealTimeClient'
-    s.version      = '1.8.1'
+    s.version      = '1.9.0'
     s.summary      = 'Amazon Web Services AppSync RealTime Client for iOS.'
   
     s.description  = 'AppSync RealTime Client provides subscription connections to AppSync websocket endpoints'

--- a/AppSyncRealTimeClient/Info.plist
+++ b/AppSyncRealTimeClient/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.1</string>
+	<string>1.9.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 *Changes on `main` branch that have not yet been released*
 
+## 1.9.0
+
+### Features
+
+- feat: Attempt to reconnect on connectivity (See [PR #58](https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/58))
+
 ## 1.8.1
 
 ### Bug fixes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Reference of previous release https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/75

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
