### PR TITLE
fix: refactor error handling

### DIFF
--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientFailureTests.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientFailureTests.swift
@@ -182,16 +182,9 @@ class AppSyncRealTimeClientFailureTests: AppSyncRealTimeClientTestBase {
         ) { event, _ in
 
             switch event {
-            case .connection(let subscriptionConnectionEvent):
-                switch subscriptionConnectionEvent {
-                case .connecting:
-                    break
-                case .connected:
-                    break
-                case .disconnected:
-                    break
-                }
-            case .data(let data):
+            case .connection:
+                break
+            case .data:
                 break
             case .failed(let error):
                 guard let connectionError = error as? ConnectionProviderError,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactor the logic for handling an `RealtimeConnectionProviderResponse` over to its extension method called `toConnectionProviderError()`. Originally i was thinking of creating a new enum, but we're already normalizing it over to `ConnectionProviderError` enum (for example, max sub and limit exeeded both map to ConnectionProvider.limitExceeded). Unless we get the entire list of errorTypes to handle and directly decode to, it doesn't seem very useful to have another hand written enum for the error payloads of RealtimeConnectionProviderResponse

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
