### PR TITLE
feat: add throttling of limitExceeded error in RealtimeConnectionProviderAsync

### DIFF
--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -220,9 +220,9 @@ public class RealtimeConnectionProvider: ConnectionProvider {
                 case .finished:
                     AppSyncLogger.verbose("limitExceededThrottleSink finished")
                 }
-        } receiveValue: { result in
-            self.updateCallback(event: .error(result))
-        }
+            } receiveValue: { result in
+                self.updateCallback(event: .error(result))
+            }
     }
 
     /// - Warning: This must be invoked from the `connectionQueue`


### PR DESCRIPTION
*Description of changes:*
feat: add throttling of limitExceeded error in RealtimeConnectionProviderAsync



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
