### PR TITLE
fix: rebase RTConnectionProvider+Websocket to Async version

### DIFF
--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnectionAsync/RealtimeConnectionProviderAsync+Websocket.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnectionAsync/RealtimeConnectionProviderAsync+Websocket.swift
@@ -60,6 +60,11 @@ extension RealtimeConnectionProviderAsync: AppSyncWebsocketDelegate {
             taskQueue.async { [weak self] in
                 self?.handleError(response: response)
             }
+        case .connectionError:
+            AppSyncLogger.verbose("[RealtimeConnectionProvider] received error")
+            taskQueue.async { [weak self] in
+                self?.handleError(response: response)
+            }
         case .subscriptionAck, .unsubscriptionAck, .data:
             if let appSyncResponse = response.toAppSyncResponse() {
                 updateCallback(event: .data(appSyncResponse))
@@ -107,42 +112,18 @@ extension RealtimeConnectionProviderAsync: AppSyncWebsocketDelegate {
     ///
     /// - Warning: This method must be invoked on the `connectionQueue`
     func handleError(response: RealtimeConnectionProviderResponse) {
-        // If we get an error in connection inprogress state, return back as connection error.
-        guard status != .inProgress else {
+        // If we get an error while the connection was inProgress state,
+        let error = response.toConnectionProviderError(connectionState: status)
+        if status == .inProgress {
             status = .notConnected
-            updateCallback(event: .error(ConnectionProviderError.connection))
-            return
         }
 
-        if response.isLimitExceededError() {
-            let limitExceedError = ConnectionProviderError.limitExceeded(response.id)
-
-            guard response.id == nil else {
-                updateCallback(event: .error(limitExceedError))
-                return
-            }
-
-            limitExceededSubject.send(limitExceedError)
-            return
+        // If limit exceeded is for a particular subscription identifier, throttle using `limitExceededSubject`
+        if case .limitExceeded(let id) = error, id == nil {
+            self.limitExceededSubject.send(error)
+        } else {
+            updateCallback(event: .error(error))
         }
-
-        if response.isMaxSubscriptionReachedError() {
-            let limitExceedError = ConnectionProviderError.limitExceeded(response.id)
-            updateCallback(event: .error(limitExceedError))
-            return
-        }
-
-        // If the type of error is not handled (by checking `isLimitExceededError`, `isMaxSubscriptionReachedError`,
-        // etc), and is not for a specific subscription, then return a generic error
-        guard let identifier = response.id else {
-            let genericError = ConnectionProviderError.other
-            updateCallback(event: .error(genericError))
-            return
-        }
-
-        // Default scenario - return the error with subscription id and error payload.
-        let subscriptionError = ConnectionProviderError.subscription(identifier, response.payload)
-        updateCallback(event: .error(subscriptionError))
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR added swift async/await concurrency support https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/85 renaming the file to RealtimeConnectionProvider**Async**+Websocket over in https://github.com/aws-amplify/aws-appsync-realtime-client-ios/commit/5b9428452bc144ced2bc8c11b59b7b604ce48dd8#diff-9e793df5ee40c091d1d4007f21ceae0c32be2fe1bda4ce651bfa321885c79c14

There were changes in the previous file that was merged in with https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/69/files

This PR is to replicate those changes in the new file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
