### PR TITLE
fix: create valid unauthorized request for odic/userpool connections

### DIFF
--- a/AppSyncRealTimeClient/Interceptor/OIDCAuthInterceptor.swift
+++ b/AppSyncRealTimeClient/Interceptor/OIDCAuthInterceptor.swift
@@ -52,7 +52,14 @@ public class OIDCAuthInterceptor: AuthInterceptor, AuthInterceptorAsync {
         case .success(let token):
             jwtToken = token
         case .failure:
-            return request
+            // A user that is not signed in should receive an unauthorized error from the connection attempt. This code
+            // achieves this by always creating a valid request to AppSync even when the token cannot be retrieved. The
+            // request sent to AppSync will receive a response indicating the request is unauthorized. If we do not use
+            // empty token string and perform the remaining logic of the request construction then it will fail request
+            // validation at AppSync before the authorization check, which ends up being propagated back to the caller
+            // as a "bad request". Example of bad requests are when the header and payload query strings are missing
+            // or when the data is not base64 encoded.
+            jwtToken = ""
         }
 
         let authHeader = UserPoolsAuthenticationHeader(token: jwtToken, host: host)

--- a/AppSyncRealTimeClientTests/Interceptor/OIDCAuthInterceptorTests.swift
+++ b/AppSyncRealTimeClientTests/Interceptor/OIDCAuthInterceptorTests.swift
@@ -10,13 +10,29 @@ import AppSyncRealTimeClient
 
 class OIDCAuthInterceptorTests: XCTestCase {
 
+    var userPoolAuthProvider: MockUserPoolsAuthProvider!
     var authInterceptor: OIDCAuthInterceptor!
 
     override func setUp() {
-        authInterceptor = OIDCAuthInterceptor(MockUserPoolsAuthProvider())
+        userPoolAuthProvider = MockUserPoolsAuthProvider()
+        authInterceptor = OIDCAuthInterceptor(userPoolAuthProvider)
     }
 
-    func testInterceptRequest() {
+    func testInterceptConnection() {
+        let url = URL(string: "http://xxxc.appsync-api.ap-southeast-2.amazonaws.com/sd")!
+        let request = AppSyncConnectionRequest(url: url)
+        let signedRequest = authInterceptor.interceptConnection(request, for: url)
+
+        guard let queries = URLComponents(url: signedRequest.url, resolvingAgainstBaseURL: true)?.queryItems else {
+            assertionFailure("Query parameters should not be nil")
+            return
+        }
+        XCTAssertTrue(queries.contains { $0.name == "header"}, "Should contain the header query")
+        XCTAssertTrue(queries.contains { $0.name == "payload"}, "Should contain the payload query")
+    }
+
+    func testInterceptConnectionWithInvalidToken() {
+        userPoolAuthProvider.hasError = true
         let url = URL(string: "http://xxxc.appsync-api.ap-southeast-2.amazonaws.com/sd")!
         let request = AppSyncConnectionRequest(url: url)
         let signedRequest = authInterceptor.interceptConnection(request, for: url)
@@ -39,7 +55,15 @@ class OIDCAuthInterceptorTests: XCTestCase {
 }
 
 class MockUserPoolsAuthProvider: OIDCAuthProvider {
+    struct AuthError: Error { }
+
+    var hasError: Bool = false
+
     func getLatestAuthToken() -> Result<String, Error> {
+        if hasError {
+            return .failure(AuthError())
+        }
+
         return .success("jwtToken")
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR is part of the efforts to propagate the unauthorized error back to the caller. In the previous PR https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/69 we are sure that it works for invalid API keys. When testing with endpoint with user pool auth mode, it would fail with a bad request.

The reason for the bad request is because retrieving the token failed, so the request was not modified before attempting the connection. AppSync will return a bad request indicating that the logic for creating the request was invalid. 

This PR is to ensure even when the user is not signed in, the library will create a valid request, which then gets validated by AppSync as Unauthorized. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
