### PR TITLE
chore: Prep 2.0.0 release

### DIFF
--- a/AppSyncRealTimeClient.podspec
+++ b/AppSyncRealTimeClient.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         = 'AppSyncRealTimeClient'
-    s.version      = '1.10.0'
+    s.version      = '2.0.0'
     s.summary      = 'Amazon Web Services AppSync RealTime Client for iOS.'
   
     s.description  = 'AppSync RealTime Client provides subscription connections to AppSync websocket endpoints'

--- a/AppSyncRealTimeClient/Info.plist
+++ b/AppSyncRealTimeClient/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.0</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Unreleased
 *Changes on `main` branch that have not yet been released*
 
+## 2.0.0
+
+- feat: Handle Unauthorized errors (See [PR #69](https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/69))
+- fix: rebase RTConnectionProvider+Websocket to Async version (See [PR #91](https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/91))
+- fix: create valid unauthorized request for odic/userpool connections (See [PR #93](https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/93))
+
+Breaking changes: `ConnectionProviderError.other` has been removed and `.unauthorized` and `.unknown` cases has been added.
+
 ## 1.10.0
 
 ### Features


### PR DESCRIPTION
*Issue #, if available:*
Ref: similar previous release link https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/87

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
