### PR TITLE
fix: fixed a bug that prevnted TaskQueue sync method from waiting for the task to complete

### DIFF
--- a/AppSyncRealTimeClient/Support/TaskQueue.swift
+++ b/AppSyncRealTimeClient/Support/TaskQueue.swift
@@ -13,11 +13,12 @@ import Foundation
 actor TaskQueue<Success> {
     private var previousTask: Task<Success, Error>?
 
-    func sync(block: @Sendable @escaping () async throws -> Success) rethrows {
+    func sync(block: @Sendable @escaping () async throws -> Success) async throws {
         previousTask = Task { [previousTask] in
             _ = await previousTask?.result
             return try await block()
         }
+        _ = try await previousTask?.value
     }
 
     nonisolated func async(block: @Sendable @escaping () async throws -> Success) rethrows {


### PR DESCRIPTION
*Description of changes:*
fix: fixed a bug that prevnted TaskQueue sync method from waiting for the task to complete

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
