### PR TITLE
feat: pass URLRequest instead of URL to interfaces

### DIFF
--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -103,18 +103,18 @@ public class RealtimeConnectionProvider: ConnectionProvider {
                 self.updateCallback(event: .connection(self.status))
                 return
             }
-            
+
             guard let url = self.urlRequest.url else {
                 self.updateCallback(event: .error(ConnectionProviderError.unknown(message: "Missing URL", payload: nil)))
                 return
             }
             self.status = .inProgress
             self.updateCallback(event: .connection(self.status))
-            
+
             let request = AppSyncConnectionRequest(url: url)
             let signedRequest = self.interceptConnection(request, for: url)
             self.urlRequest.url = signedRequest.url
-            
+
             DispatchQueue.global().async {
                 self.websocket.connect(
                     urlRequest: self.urlRequest,

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -103,11 +103,14 @@ public class RealtimeConnectionProvider: ConnectionProvider {
                 self.updateCallback(event: .connection(self.status))
                 return
             }
-            self.status = .inProgress
-            self.updateCallback(event: .connection(self.status))
+            
             guard let url = self.urlRequest.url else {
+                self.updateCallback(event: .error(ConnectionProviderError.unknown(message: "Missing URL", payload: nil)))
                 return
             }
+            self.status = .inProgress
+            self.updateCallback(event: .connection(self.status))
+            
             let request = AppSyncConnectionRequest(url: url)
             let signedRequest = self.interceptConnection(request, for: url)
             self.urlRequest.url = signedRequest.url
@@ -129,6 +132,7 @@ public class RealtimeConnectionProvider: ConnectionProvider {
                 return
             }
             guard let url = self.urlRequest.url else {
+                self.updateCallback(event: .error(ConnectionProviderError.unknown(message: "Missing URL", payload: nil)))
                 return
             }
             let signedMessage = self.interceptMessage(message, for: url)

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -15,7 +15,7 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     /// message before we consider it stale and force a disconnect
     static let staleConnectionTimeout: TimeInterval = 5 * 60
 
-    private var urlRequest: URLRequest
+    private let urlRequest: URLRequest
     var listeners: [String: ConnectionProviderCallback]
 
     let websocket: AppSyncWebsocketProvider
@@ -105,7 +105,10 @@ public class RealtimeConnectionProvider: ConnectionProvider {
             }
 
             guard let url = self.urlRequest.url else {
-                self.updateCallback(event: .error(ConnectionProviderError.unknown(message: "Missing URL", payload: nil)))
+                self.updateCallback(event: .error(ConnectionProviderError.unknown(
+                    message: "Missing URL",
+                    payload: nil
+                )))
                 return
             }
             self.status = .inProgress
@@ -113,11 +116,12 @@ public class RealtimeConnectionProvider: ConnectionProvider {
 
             let request = AppSyncConnectionRequest(url: url)
             let signedRequest = self.interceptConnection(request, for: url)
-            self.urlRequest.url = signedRequest.url
+            var urlRequest = self.urlRequest
+            urlRequest.url = signedRequest.url
 
             DispatchQueue.global().async {
                 self.websocket.connect(
-                    urlRequest: self.urlRequest,
+                    urlRequest: urlRequest,
                     protocols: ["graphql-ws"],
                     delegate: self
                 )
@@ -132,7 +136,10 @@ public class RealtimeConnectionProvider: ConnectionProvider {
                 return
             }
             guard let url = self.urlRequest.url else {
-                self.updateCallback(event: .error(ConnectionProviderError.unknown(message: "Missing URL", payload: nil)))
+                self.updateCallback(event: .error(ConnectionProviderError.unknown(
+                    message: "Missing URL",
+                    payload: nil
+                )))
                 return
             }
             let signedMessage = self.interceptMessage(message, for: url)

--- a/AppSyncRealTimeClient/ConnectionProvider/ConnectionProviderFactory.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/ConnectionProviderFactory.swift
@@ -11,7 +11,7 @@ import Foundation
 public enum ConnectionProviderFactory {
 
     public static func createConnectionProvider(
-        for url: URL,
+        for urlRequest: URLRequest,
         authInterceptor: AuthInterceptor,
         connectionType: SubscriptionConnectionType
     ) -> ConnectionProvider {
@@ -20,7 +20,7 @@ public enum ConnectionProviderFactory {
         switch connectionType {
         case .appSyncRealtime:
             let websocketProvider = StarscreamAdapter()
-            provider = RealtimeConnectionProvider(for: url, websocket: websocketProvider)
+            provider = RealtimeConnectionProvider(for: urlRequest, websocket: websocketProvider)
         }
 
         if let messageInterceptable = provider as? MessageInterceptable {
@@ -37,7 +37,7 @@ public enum ConnectionProviderFactory {
     #if swift(>=5.5.2)
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     public static func createConnectionProviderAsync(
-        for url: URL,
+        for urlRequest: URLRequest,
         authInterceptor: AuthInterceptorAsync,
         connectionType: SubscriptionConnectionType
     ) -> ConnectionProvider {
@@ -46,7 +46,7 @@ public enum ConnectionProviderFactory {
         switch connectionType {
         case .appSyncRealtime:
             let websocketProvider = StarscreamAdapter()
-            provider = RealtimeConnectionProviderAsync(for: url, websocket: websocketProvider)
+            provider = RealtimeConnectionProviderAsync(for: urlRequest, websocket: websocketProvider)
         }
 
         if let messageInterceptable = provider as? MessageInterceptableAsync {

--- a/AppSyncRealTimeClient/Websocket/AppSyncWebsocketProvider.swift
+++ b/AppSyncRealTimeClient/Websocket/AppSyncWebsocketProvider.swift
@@ -14,7 +14,7 @@ public protocol AppSyncWebsocketProvider {
     ///
     /// This is an async call. After the connection is succesfully established, the delegate
     /// will receive the callback on `websocketDidConnect(:)`
-    func connect(url: URL, protocols: [String], delegate: AppSyncWebsocketDelegate?)
+    func connect(urlRequest: URLRequest, protocols: [String], delegate: AppSyncWebsocketDelegate?)
 
     /// Disconnects the websocket.
     func disconnect()

--- a/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
+++ b/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
@@ -38,7 +38,7 @@ public class StarscreamAdapter: AppSyncWebsocketProvider {
         serialQueue.async {
             AppSyncLogger.verbose("[StarscreamAdapter] connect. Connecting to url")
             var urlRequest = urlRequest
-            
+
             urlRequest.setValue("no-store", forHTTPHeaderField: "Cache-Control")
 
             let protocolHeaderValue = protocols.joined(separator: ", ")

--- a/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
+++ b/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
@@ -34,10 +34,11 @@ public class StarscreamAdapter: AppSyncWebsocketProvider {
         self.callbackQueue = callbackQueue
     }
 
-    public func connect(url: URL, protocols: [String], delegate: AppSyncWebsocketDelegate?) {
+    public func connect(urlRequest: URLRequest, protocols: [String], delegate: AppSyncWebsocketDelegate?) {
         serialQueue.async {
             AppSyncLogger.verbose("[StarscreamAdapter] connect. Connecting to url")
-            var urlRequest = URLRequest(url: url)
+            var urlRequest = urlRequest
+            
             urlRequest.setValue("no-store", forHTTPHeaderField: "Cache-Control")
 
             let protocolHeaderValue = protocols.joined(separator: ", ")

--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientAsync/AppSyncRealTimeClientAsyncFailureTests.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientAsync/AppSyncRealTimeClientAsyncFailureTests.swift
@@ -16,7 +16,7 @@ class AppSyncRealTimeClientAsyncFailureTests: AppSyncRealTimeClientTestBase {
         subscribeSuccess.expectedFulfillmentCount = 100
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProviderAsync(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )
@@ -91,7 +91,7 @@ class AppSyncRealTimeClientAsyncFailureTests: AppSyncRealTimeClientTestBase {
         subscribeSuccess.expectedFulfillmentCount = 100
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProviderAsync(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )

--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientAsync/AppSyncRealTimeClientAsyncIntegrationTests.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientAsync/AppSyncRealTimeClientAsyncIntegrationTests.swift
@@ -23,7 +23,7 @@ class AppSyncRealTimeClientAsyncIntegrationTests: AppSyncRealTimeClientTestBase 
         let subscribeSuccess = expectation(description: "subscribe successfully")
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProviderAsync(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )
@@ -75,7 +75,7 @@ class AppSyncRealTimeClientAsyncIntegrationTests: AppSyncRealTimeClientTestBase 
 
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProviderAsync(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )
@@ -170,7 +170,7 @@ class AppSyncRealTimeClientAsyncIntegrationTests: AppSyncRealTimeClientTestBase 
     func testSubscribeUnsubscribeRepeat() {
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProviderAsync(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )
@@ -197,7 +197,7 @@ class AppSyncRealTimeClientAsyncIntegrationTests: AppSyncRealTimeClientTestBase 
     func testMultipleThreadsSubscribeUnsubscribe() {
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProviderAsync(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )

--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientFailureTests.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientFailureTests.swift
@@ -16,7 +16,7 @@ class AppSyncRealTimeClientFailureTests: AppSyncRealTimeClientTestBase {
         subscribeSuccess.expectedFulfillmentCount = 100
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProvider(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )
@@ -91,7 +91,7 @@ class AppSyncRealTimeClientFailureTests: AppSyncRealTimeClientTestBase {
         subscribeSuccess.expectedFulfillmentCount = 100
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProvider(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )
@@ -171,7 +171,7 @@ class AppSyncRealTimeClientFailureTests: AppSyncRealTimeClientTestBase {
         let subscribeFailed = expectation(description: "subscribe failed")
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProvider(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )

--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientIntegrationTests.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientIntegrationTests.swift
@@ -23,7 +23,7 @@ class AppSyncRealTimeClientIntegrationTests: AppSyncRealTimeClientTestBase {
         let subscribeSuccess = expectation(description: "subscribe successfully")
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProvider(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )
@@ -75,7 +75,7 @@ class AppSyncRealTimeClientIntegrationTests: AppSyncRealTimeClientTestBase {
 
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProvider(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )
@@ -170,7 +170,7 @@ class AppSyncRealTimeClientIntegrationTests: AppSyncRealTimeClientTestBase {
     func testSubscribeUnsubscribeRepeat() {
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProvider(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )
@@ -197,7 +197,7 @@ class AppSyncRealTimeClientIntegrationTests: AppSyncRealTimeClientTestBase {
     func testMultipleThreadsSubscribeUnsubscribe() {
         let authInterceptor = APIKeyAuthInterceptor(apiKey)
         let connectionProvider = ConnectionProviderFactory.createConnectionProvider(
-            for: url,
+            for: urlRequest,
             authInterceptor: authInterceptor,
             connectionType: .appSyncRealtime
         )

--- a/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientTestBase.swift
+++ b/AppSyncRealTimeClientIntegrationTests/AppSyncRealTimeClientTestBase.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class AppSyncRealTimeClientTestBase: XCTestCase {
 
-    var url: URL!
+    var urlRequest: URLRequest!
     var apiKey: String!
     let requestString = """
         subscription onCreate {
@@ -35,7 +35,8 @@ class AppSyncRealTimeClientTestBase: XCTestCase {
                 let endpoint = apiName["endpoint"] as? String,
                 let apiKey = apiName["apiKey"] as? String {
 
-                url = URL(string: endpoint)
+                urlRequest = URLRequest(url: URL(string: endpoint)!)
+
                 self.apiKey = apiKey
             } else {
                 throw "Could not retrieve endpoint"

--- a/AppSyncRealTimeClientIntegrationTests/StarscreamAdapterTests.swift
+++ b/AppSyncRealTimeClientIntegrationTests/StarscreamAdapterTests.swift
@@ -14,13 +14,14 @@ class StarscreamAdapterTests: AppSyncRealTimeClientTestBase {
     func testConnectDisconnect() throws {
         let starscreamAdapter = StarscreamAdapter()
         let apiKeyAuthInterceptor = APIKeyAuthInterceptor(apiKey)
-        let request = AppSyncConnectionRequest(url: url)
-        let signedRequest = apiKeyAuthInterceptor.interceptConnection(request, for: url)
+        let request = AppSyncConnectionRequest(url: urlRequest.url!)
+        let signedRequest = apiKeyAuthInterceptor.interceptConnection(request, for: urlRequest.url!)
+        urlRequest.url = signedRequest.url
         let expectedPerforms = expectation(description: "total performs")
         expectedPerforms.expectedFulfillmentCount = 1_000
         DispatchQueue.concurrentPerform(iterations: 1_000) { _ in
             starscreamAdapter.connect(
-                url: signedRequest.url,
+                urlRequest: urlRequest,
                 protocols: ["graphql-ws"],
                 delegate: nil
             )

--- a/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderAsync/RealtimeConnectionProviderAsyncTestBase.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderAsync/RealtimeConnectionProviderAsyncTestBase.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class RealtimeConnectionProviderAsyncTestBase: XCTestCase {
 
-    let url = URL(string: "https://www.appsyncrealtimeclient.test/")!
+    let urlRequest = URLRequest(url: URL(string: "https://www.appsyncrealtimeclient.test/")!)
 
     var websocket: MockWebsocketProvider!
 
@@ -47,7 +47,7 @@ class RealtimeConnectionProviderAsyncTestBase: XCTestCase {
         connectivityMonitor: ConnectivityMonitor = ConnectivityMonitor()
     ) -> RealtimeConnectionProvider {
         let provider = RealtimeConnectionProvider(
-            url: url,
+            urlRequest: urlRequest,
             websocket: websocket,
             serialCallbackQueue: serialCallbackQueue,
             connectivityMonitor: connectivityMonitor

--- a/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderHandleErrorTests.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/ConnectionProviderHandleErrorTests.swift
@@ -9,13 +9,13 @@ import XCTest
 @testable import AppSyncRealTimeClient
 
 class ConnectionProviderHandleErrorTests: XCTestCase {
-    let url = URL(string: "https://www.appsyncrealtimeclient.test/")!
+    let urlRequest = URLRequest(url: URL(string: "https://www.appsyncrealtimeclient.test/")!)
     var websocket = MockWebsocketProvider()
 
     /// Error response is limit exceeded with id
     /// Should receive ConnectionProviderError.limitExceeded with id
     func testLimitExceededWithId() {
-        let provider = RealtimeConnectionProvider(url: url, websocket: websocket)
+        let provider = RealtimeConnectionProvider(urlRequest: urlRequest, websocket: websocket)
 
         let subscriptionEvent = expectation(description: "Receieved subscription event")
         provider.addListener(identifier: "id") { event in
@@ -42,7 +42,7 @@ class ConnectionProviderHandleErrorTests: XCTestCase {
     /// Should throttle and receive a fraction of ConnectionProviderError.limitExceeded event without id
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testLimitExceededMissingIdThrottled() {
-        let provider = RealtimeConnectionProvider(url: url, websocket: websocket)
+        let provider = RealtimeConnectionProvider(urlRequest: urlRequest, websocket: websocket)
         let limitExceededThrottle = expectation(description: "received limit exceeded")
         limitExceededThrottle.expectedFulfillmentCount = 100
         let sink = provider.limitExceededSubject.sink { error in
@@ -86,7 +86,7 @@ class ConnectionProviderHandleErrorTests: XCTestCase {
     /// Error response is max subscription with subscription id
     /// Should receive ConnectionProviderError.limitExceeded with id
     func testMaxSubscriptionReached() {
-        let provider = RealtimeConnectionProvider(url: url, websocket: websocket)
+        let provider = RealtimeConnectionProvider(urlRequest: urlRequest, websocket: websocket)
 
         let subscriptionEvent = expectation(description: "Receieved subscription event")
         provider.addListener(identifier: "id") { event in
@@ -112,7 +112,7 @@ class ConnectionProviderHandleErrorTests: XCTestCase {
     /// Error response with no indication for which subscription and missing payload
     /// Should receive ConnectionProviderError.other
     func testMissingId() throws {
-        let provider = RealtimeConnectionProvider(url: url, websocket: websocket)
+        let provider = RealtimeConnectionProvider(urlRequest: urlRequest, websocket: websocket)
 
         let subscriptionEvent = expectation(description: "Receieved subscription event")
         provider.addListener(identifier: "id") { event in
@@ -137,7 +137,7 @@ class ConnectionProviderHandleErrorTests: XCTestCase {
     /// Error response subscription id and payload
     /// Should receive ConnectionProviderError.subscription(id, payload)
     func testWithSubscriptionId() throws {
-        let provider = RealtimeConnectionProvider(url: url, websocket: websocket)
+        let provider = RealtimeConnectionProvider(urlRequest: urlRequest, websocket: websocket)
 
         let subscriptionEvent = expectation(description: "Receieved subscription event")
         provider.addListener(identifier: "id") { event in

--- a/AppSyncRealTimeClientTests/ConnectionProvider/RealtimeConnectionProviderTestBase.swift
+++ b/AppSyncRealTimeClientTests/ConnectionProvider/RealtimeConnectionProviderTestBase.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class RealtimeConnectionProviderTestBase: XCTestCase {
 
-    let url = URL(string: "https://www.appsyncrealtimeclient.test/")!
+    let urlRequest = URLRequest(url: URL(string: "https://www.appsyncrealtimeclient.test/")!)
 
     var websocket: MockWebsocketProvider!
 
@@ -50,7 +50,7 @@ class RealtimeConnectionProviderTestBase: XCTestCase {
         connectivityMonitor: ConnectivityMonitor = ConnectivityMonitor()
     ) -> RealtimeConnectionProvider {
         let provider = RealtimeConnectionProvider(
-            url: url,
+            urlRequest: urlRequest,
             websocket: websocket,
             connectionQueue: connectionQueue,
             serialCallbackQueue: serialCallbackQueue,

--- a/AppSyncRealTimeClientTests/Mocks/MockWebsocketProvider.swift
+++ b/AppSyncRealTimeClientTests/Mocks/MockWebsocketProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 import AppSyncRealTimeClient
 
 class MockWebsocketProvider: AppSyncWebsocketProvider {
-    typealias OnConnect = (URL, [String], AppSyncWebsocketDelegate?) -> Void
+    typealias OnConnect = (URLRequest, [String], AppSyncWebsocketDelegate?) -> Void
     typealias OnDisconnect = () -> Void
     typealias OnWrite = (String) -> Void
 
@@ -30,8 +30,8 @@ class MockWebsocketProvider: AppSyncWebsocketProvider {
         self.onWrite = onWrite
     }
 
-    func connect(url: URL, protocols: [String], delegate: AppSyncWebsocketDelegate?) {
-        onConnect?(url, protocols, delegate)
+    func connect(urlRequest: URLRequest, protocols: [String], delegate: AppSyncWebsocketDelegate?) {
+        onConnect?(urlRequest, protocols, delegate)
     }
 
     func disconnect() {

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 			dependencies = (
 			);
 			name = SwiftFormat;
-			productName = SwiftFormat;
 		};
 		52B60EC2A583F24ACBB69C113F5488B9 /* SwiftLint */ = {
 			isa = PBXAggregateTarget;
@@ -25,7 +24,6 @@
 			dependencies = (
 			);
 			name = SwiftLint;
-			productName = SwiftLint;
 		};
 /* End PBXAggregateTarget section */
 
@@ -205,7 +203,7 @@
 		999D7A0732B0168D9EB631C456DEC8A3 /* Pods-AppSyncRealTimeClient-AppSyncRealTimeClientTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AppSyncRealTimeClient-AppSyncRealTimeClientTests.release.xcconfig"; sourceTree = "<group>"; };
 		9B273836AFE7E07EE713B29F94B54285 /* Starscream.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Starscream.release.xcconfig; sourceTree = "<group>"; };
 		9D2BCC3D81009251CF149E4E6A0C224E /* StringHTTPHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringHTTPHandler.swift; path = Sources/Framer/StringHTTPHandler.swift; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9FF7D529C51D3F1B0D444B08C40EE3AD /* Pods-AppSyncRTCSample-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-AppSyncRTCSample-frameworks.sh"; sourceTree = "<group>"; };
 		A26BD722B33E83A41BD4A44DD2BDC4E3 /* Pods-AppSyncRTCSample-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-AppSyncRTCSample-umbrella.h"; sourceTree = "<group>"; };
 		A31447240FB4AA22B5D3E1287DAF4DCB /* Pods-HostApp-AppSyncRealTimeClientIntegrationTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-HostApp-AppSyncRealTimeClientIntegrationTests-acknowledgements.markdown"; sourceTree = "<group>"; };
@@ -329,6 +327,7 @@
 				F07B207CD9F5DF97C2D649C58C619BB7 /* WSEngine.swift */,
 				83681F15B53C4D30045511A41B8A97FD /* Support Files */,
 			);
+			name = Starscream;
 			path = Starscream;
 			sourceTree = "<group>";
 		};
@@ -444,6 +443,7 @@
 			children = (
 				37E4C763E3D1AD54AEBD3E13FA588594 /* Support Files */,
 			);
+			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
@@ -469,6 +469,7 @@
 			children = (
 				120316207F6661A29A01BB8F9BBEF8F1 /* Support Files */,
 			);
+			name = SwiftFormat;
 			path = SwiftFormat;
 			sourceTree = "<group>";
 		};
@@ -1172,7 +1173,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1295,7 +1296,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
These are some changes necessary to allow passing in a URLRequest instead of URL. Because of the change, this will be released as a major version bump v3.0.0.

*Integration Testing*
Swift Package doesn't have the integration test target, which makes sense since we do not produce it as a product for customers. Had to run `pod install` and open the xcworkspace to access the integration test target.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
