### PR TITLE
chore: Update CODEOWNERS [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*        @aws-amplify/amplify-data
+*        @aws-amplify/amplify-ios


### PR DESCRIPTION
Similar to aws-amplify/aws-appsync-realtime-client-ios#89

This PR moves the code owners `@aws-amplify/amplify-ios`
