### PR TITLE
fix: pin starscream to 4.0.4

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "daltoniam/starscream" ~> 4.0.4
+github "daltoniam/starscream" == 4.0.4

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["AppSyncRealTimeClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/daltoniam/Starscream", .upToNextMinor(from: "4.0.4"))
+        .package(url: "https://github.com/daltoniam/Starscream", .exact("4.0.4"))
     ],
     targets: [
         .target(

--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ target 'AppSyncRealTimeClient' do
   # Pods for AppSyncRealTimeClient
   
   # If you update this dependency version, be sure to update the Cartfile also
-  pod "Starscream", "~> 4.0.4"
+  pod "Starscream", "4.0.4"
   
   include_build_tools!
 


### PR DESCRIPTION
*Issue #, if available:*
related: https://github.com/aws-amplify/amplify-flutter/pull/3584

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
