### PR TITLE
chore: Prep 3.1.1 release

### DIFF
--- a/AppSyncRealTimeClient.podspec
+++ b/AppSyncRealTimeClient.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         = 'AppSyncRealTimeClient'
-    s.version      = '3.1.0'
+    s.version      = '3.1.1'
     s.summary      = 'Amazon Web Services AppSync RealTime Client for iOS.'
   
     s.description  = 'AppSync RealTime Client provides subscription connections to AppSync websocket endpoints'
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.requires_arc = true
     
     s.source_files = 'AppSyncRealTimeClient/**/*.swift'
-    s.dependency 'Starscream', '~> 4.0.4'
+    s.dependency 'Starscream', '4.0.4'
   end

--- a/AppSyncRealTimeClient/Info.plist
+++ b/AppSyncRealTimeClient/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.0</string>
+	<string>3.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 *Changes on `main` branch that have not yet been released*
 
+## 3.1.1
+- fix: pin starscream to 4.0.4 ([#132](https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/132))
+
 ## 3.1.0
 
 ### Features


### PR DESCRIPTION
*Description of changes:*
Bumps version to 3.1.1 and pins starscream dependency to 4.0.4 in the podspec.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
