### PR TITLE
fix: skip network monitoring for watchOS

### DIFF
--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -85,7 +85,13 @@ public class RealtimeConnectionProvider: ConnectionProvider {
         self.serialCallbackQueue = serialCallbackQueue
         self.connectivityMonitor = connectivityMonitor
 
+        // On a physical watchOS device, it is showing "unsatisfied" despite connected to the internet
+        // according to https://developer.apple.com/forums/thread/729568
+        // To avoid an incorrect network status state for the system, do not use connectivity monitor
+        // for watchOS apps.
+        #if !os(watchOS)
         connectivityMonitor.start(onUpdates: handleConnectivityUpdates(connectivity:))
+        #endif
 
         if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
             subscribeToLimitExceededThrottle()

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnectionAsync/RealtimeConnectionProviderAsync.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnectionAsync/RealtimeConnectionProviderAsync.swift
@@ -80,7 +80,14 @@ public class RealtimeConnectionProviderAsync: ConnectionProvider {
         self.serialCallbackQueue = serialCallbackQueue
         self.connectivityMonitor = connectivityMonitor
 
+        // On a physical watchOS device, it is showing "unsatisfied" despite connected to the internet
+        // according to https://developer.apple.com/forums/thread/729568
+        // To avoid an incorrect network status state for the system, do not use connectivity monitor
+        // for watchOS apps.
+        #if !os(watchOS)
         connectivityMonitor.start(onUpdates: handleConnectivityUpdates(connectivity:))
+        #endif
+        
         subscribeToLimitExceededThrottle()
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
