### PR TITLE
fix: watchOS support - disable network monitoring, add client timeout

### DIFF
--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -85,7 +85,13 @@ public class RealtimeConnectionProvider: ConnectionProvider {
         self.serialCallbackQueue = serialCallbackQueue
         self.connectivityMonitor = connectivityMonitor
 
+        // On a physical watchOS device, it is showing "unsatisfied" despite connected to the internet
+        // according to https://developer.apple.com/forums/thread/729568
+        // To avoid an incorrect network status state for the system, do not use connectivity monitor
+        // for watchOS apps.
+        #if !os(watchOS)
         connectivityMonitor.start(onUpdates: handleConnectivityUpdates(connectivity:))
+        #endif
 
         if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
             subscribeToLimitExceededThrottle()

--- a/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnectionAsync/RealtimeConnectionProviderAsync.swift
+++ b/AppSyncRealTimeClient/ConnectionProvider/AppsyncRealtimeConnectionAsync/RealtimeConnectionProviderAsync.swift
@@ -80,7 +80,14 @@ public class RealtimeConnectionProviderAsync: ConnectionProvider {
         self.serialCallbackQueue = serialCallbackQueue
         self.connectivityMonitor = connectivityMonitor
 
+        // On a physical watchOS device, it is showing "unsatisfied" despite connected to the internet
+        // according to https://developer.apple.com/forums/thread/729568
+        // To avoid an incorrect network status state for the system, do not use connectivity monitor
+        // for watchOS apps.
+        #if !os(watchOS)
         connectivityMonitor.start(onUpdates: handleConnectivityUpdates(connectivity:))
+        #endif
+        
         subscribeToLimitExceededThrottle()
     }
 

--- a/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
+++ b/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
@@ -23,6 +23,8 @@ public class StarscreamAdapter: AppSyncWebsocketProvider {
         }
     }
 
+    let watchOSConnectivityTimer: CountdownTimer
+    
     public init() {
         let serialQueue = DispatchQueue(label: "com.amazonaws.StarscreamAdapter.serialQueue")
         let callbackQueue = DispatchQueue(
@@ -32,6 +34,7 @@ public class StarscreamAdapter: AppSyncWebsocketProvider {
         self._isConnected = false
         self.serialQueue = serialQueue
         self.callbackQueue = callbackQueue
+        self.watchOSConnectivityTimer = CountdownTimer()
     }
 
     public func connect(urlRequest: URLRequest, protocols: [String], delegate: AppSyncWebsocketDelegate?) {
@@ -49,6 +52,7 @@ public class StarscreamAdapter: AppSyncWebsocketProvider {
             self.socket?.delegate = self
             self.socket?.callbackQueue = self.callbackQueue
             self.socket?.connect()
+            self.startWatchOSConnectivityTimer()
         }
     }
 
@@ -65,5 +69,32 @@ public class StarscreamAdapter: AppSyncWebsocketProvider {
             AppSyncLogger.verbose("[StarscreamAdapter] socket.write - \(message)")
             self.socket?.write(string: message)
         }
+    }
+    
+    private func startWatchOSConnectivityTimer() {
+        #if os(watchOS)
+        let watchOSConnectTimeoutInSeconds = TimeInterval(5)
+        AppSyncLogger.debug(
+            "[StarscreamAdapter] Starting connectivity timer for watchOS for \(watchOSConnectTimeoutInSeconds)s."
+        )
+        self.watchOSConnectivityTimer.start(interval: watchOSConnectTimeoutInSeconds) {
+            AppSyncLogger.debug(
+                "[StarscreamAdapter] watchOS connectivity timer is up."
+            )
+            self.serialQueue.async {
+                if !self._isConnected {
+                    AppSyncLogger.debug(
+                        "[StarscreamAdapter] Subscriptions not connected after \(watchOSConnectTimeoutInSeconds)s. Manually disconnecting"
+                    )
+                    let error = ConnectionProviderError.connection
+                    self.delegate?.websocketDidDisconnect(provider: self, error: error)
+                } else {
+                    AppSyncLogger.debug(
+                        "[StarscreamAdapter] Subscriptions are connected within \(watchOSConnectTimeoutInSeconds)s."
+                    )
+                }
+            }
+        }
+        #endif
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

## Table of Contents

1. [fix(DataStore): Store larger than 32-bit values in Int64 over Int #3367](https://github.com/aws-amplify/amplify-swift/pull/3367)
2. [feat(DataStore): DisableSubscriptions flag for watchOS #3368](https://github.com/aws-amplify/amplify-swift/pull/3368)
3. [fix: watchOS support - disable network monitoring, add client timeout #141](https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/141) (You are here)

*Description of changes:*
Network Path Monitoring will return `unsatisified` on watchOS devices since it is considered low-level networking and cannot be used.

This PR avoids using network path monitoring for watchOS so that it will try to attempt to connect if subscribe API is called. This is a critical piece of logic that is required for the enabled subscriptions use case.

For example, when using DataStore on watchOS, and subscriptions are enabled, we want the logic to at least attempt to connect.

The connection may fail if special circumstances are not met, thus, we implement a client timeout to disconnect and signal back the caller that the subscription is disconnected.

When all are aligned: watchOS special circumstances is met, DataStore subscriptions enabled, subscribe API is called, then the connection should be established and the client timeout will do nothing once it fires.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
