### PR TITLE
fix(ci): remove build-and-test workflow from release

### DIFF
--- a/.github/workflows/deploy-pods.yml
+++ b/.github/workflows/deploy-pods.yml
@@ -29,13 +29,9 @@ jobs:
             const matches = `${{ github.event.pull_request.title }}`.match(/[0-9]+\.[0-9]+\.[0-9]+/) ?? []
             return matches.length > 0 ? matches[0] : ""
 
-  build-and-test:
-    needs: [extract-release-version]
-    uses: ./.github/workflows/build-and-test.yml
-
   release:
     environment: CocoaPodsRelease
-    needs: [build-and-test, extract-release-version]
+    needs: [extract-release-version]
     runs-on: macos-latest
     env:
       RELEASE_VERSION: ${{ needs.extract-release-version.outputs.version }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- remove `build-and-test` step from release workflow as it should have been ran in another triggerred

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
