### PR TITLE
fix: Fixing Build and Test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,8 +43,5 @@ jobs:
       - name: Install Pods
         run: bundle exec pod install
 
-      - name: Build AppSyncRealTimeClient
-        run: xcodebuild build-for-testing -workspace AppSyncRealTimeClient.xcworkspace -scheme AppSyncRealTimeClient -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty
-
       - name: Test AppSyncRealTimeClient
-        run: xcodebuild test -workspace AppSyncRealTimeClient.xcworkspace -scheme AppSyncRealTimeClient -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty --simple --color --report junit
+        run: xcodebuild test -workspace AppSyncRealTimeClient.xcworkspace -scheme AppSyncRealTimeClient -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
**Description of changes:**

The **build-and-test** workflow was missing the `&& exit ${PIPESTATUS[0]}` command when running the tests, causing it to fail to report the actual status of the operation.
Because of that, if the tests failed the workflow would still succeed.

I'm also removing the "Build AppSyncRealTimeClient" step because it's unnecessary, running `xcodebuild test` will also build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
