### PR TITLE
fix(ci): add event triggers for PR created by API

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - main
+  repository_dispatch:
+    types: [create-pull-request]
 
 permissions:
       contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+  repository_dispatch:
+    types: [create-pull-request]
 
 permissions:
   contents: read


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
According to discussion found [here](https://github.com/orgs/community/discussions/65321), a PR that created by API is not able to trigger actions with the existing action event triggers. Adding the suggested `respository_dispatch` event trigger for release PR.
```
  repository_dispatch:
    types: [create-pull-request]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
