### PR TITLE
chore: Temporary using xcodeproj's commit that bumps rexml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'xcpretty', '0.3.0'
 gem 'cocoapods', '1.11.3'
 gem 'cocoapods-downloader', '1.6.3'
 gem 'fastlane', '2.205.1'
+gem "xcodeproj", git: "https://github.com/CocoaPods/Xcodeproj.git", :branch => "master", ref: "fe55cf5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,23 @@
+GIT
+  remote: https://github.com/CocoaPods/Xcodeproj.git
+  revision: fe55cf57badef2ca27fb9d4f801d9b834de1f871
+  ref: fe55cf5
+  branch: master
+  specs:
+    xcodeproj (1.24.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (>= 3.3.2, < 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
     activesupport (6.1.7.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -33,6 +49,7 @@ GEM
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
+    base64 (0.2.0)
     claide (1.1.0)
     cocoapods (1.11.3)
       addressable (~> 2.8)
@@ -217,6 +234,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
+    nkf (0.2.0)
     optparse (0.1.1)
     os (1.1.4)
     plist (3.6.0)
@@ -227,8 +245,8 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rouge (2.0.7)
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)
@@ -262,13 +280,6 @@ GEM
     unicode-display_width (1.8.0)
     webrick (1.7.0)
     word_wrap (1.0.0)
-    xcodeproj (1.21.0)
-      CFPropertyList (>= 2.3.3, < 4.0)
-      atomos (~> 0.1.3)
-      claide (>= 1.0.2, < 2.0)
-      colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
@@ -282,6 +293,7 @@ DEPENDENCIES
   cocoapods (= 1.11.3)
   cocoapods-downloader (= 1.6.3)
   fastlane (= 2.205.1)
+  xcodeproj!
   xcpretty (= 0.3.0)
 
 BUNDLED WITH


### PR DESCRIPTION
**Description of changes:**

This PR uses Xcodeproj's latest [main commit](https://github.com/CocoaPods/Xcodeproj/commit/fe55cf57badef2ca27fb9d4f801d9b834de1f871) so that its dependency to `rexml` can be upgraded.

We're doing this temporary until they release a proper new version, at which point we will point to that one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
